### PR TITLE
Added a function to replace  Reserved html characters

### DIFF
--- a/src/Serilog.Ui.Web/wwwroot/dist/main.js
+++ b/src/Serilog.Ui.Web/wwwroot/dist/main.js
@@ -159,7 +159,7 @@ const fetchData = () => {
                 <td class="text-center"><span class="log-level text-white ${levelClass(log.level)}">${log.level}</span></td>
                 <td class="text-center">${formatDate(log.timestamp)}</td>
                 <td class="log-message">
-                    <span class="overflow-auto"><truncate length="100">${truncateString(log.message, 100)}</truncate></span>
+                    <span class="overflow-auto"><truncate length="100">${truncateString(cleanHtmlTags(log.message), 100)}</truncate></span>
                 </td>
                 <td class="text-center">
                     ${exception}
@@ -289,4 +289,8 @@ const initTokenUi = () => {
     $("#tokenContainer").text("*********");
     $("#saveJwt").text("Clear").data("saved", "true");
     $("#jwtModalBtn").find("i").removeClass("fa-unlock").addClass("fa-lock");
+}
+
+const cleanHtmlTags=  (str)=> {
+    return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }


### PR DESCRIPTION
When there are `HTML` tags in `log.message` , it shows as below (actually html tags are shown as  rendered html) : 

![image](https://user-images.githubusercontent.com/45357615/143499161-31653878-116d-403b-8764-49df10056284.png)

To prevent `HTML` tags from being rendered, I added a `js` function to replace `HTML` Reserved characters with their Entity Names.
Apart from `HTML` tags, it is also useful for showing `.NET` exceptions correctly while there are `<,>` in exception messages.

![image](https://user-images.githubusercontent.com/45357615/143499557-d509dead-efa3-4b09-98f9-cd5d01cd9394.png)

