### PR TITLE
use TryAddSigleton to prevent service override in clients

### DIFF
--- a/src/Serilog.Ui.MongoDbProvider/Extensions/SerilogUiOptionBuilderExtensions.cs
+++ b/src/Serilog.Ui.MongoDbProvider/Extensions/SerilogUiOptionBuilderExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using MongoDB.Driver;
 using Serilog.Ui.Core;
 using System;
@@ -38,7 +39,7 @@ namespace Serilog.Ui.MongoDbProvider
             };
 
             ((ISerilogUiOptionsBuilder)optionsBuilder).Services.AddSingleton(mongoProvider);
-            ((ISerilogUiOptionsBuilder)optionsBuilder).Services.AddSingleton<IMongoClient>(o => new MongoClient(connectionString));
+            ((ISerilogUiOptionsBuilder)optionsBuilder).Services.TryAddSingleton<IMongoClient>(o => new MongoClient(connectionString));
             ((ISerilogUiOptionsBuilder)optionsBuilder).Services.AddScoped<IDataProvider, MongoDbDataProvider>();
         }
 


### PR DESCRIPTION
Hi 😄 
This PR would like to review the IMongoClient Singleton Registration.

When a client uses the MongoDB provider, probably the IMongoClient it's already registered as a singleton (as recommended by the official SDK docs). 
By using TryAddSingleton, serilog-ui will register the class only if the client didn't already do it.
It won't override anymore a custom IMongoClient singleton implementation added before [AddSerilogUi(...)](https://github.com/mo-esmp/serilog-ui/blob/209778e40758fa3b1cb1dd5e55534b3fc2e8ea0d/src/Serilog.Ui.Web/Extensions/ServiceCollectionExtensions.cs#L10) in ConfigureServices.

Let me know if there's anything unclear or wrong with this change!