### PR TITLE
Improve date management and manipulation

### DIFF
--- a/src/Serilog.Ui.MongoDbProvider/MongoDbDataProvider.cs
+++ b/src/Serilog.Ui.MongoDbProvider/MongoDbDataProvider.cs
@@ -98,10 +98,16 @@ namespace Serilog.Ui.MongoDbProvider
                 builder &= Builders<MongoDbLogModel>.Filter.Text(searchCriteria);
 
             if (startDate != null)
-                builder &= Builders<MongoDbLogModel>.Filter.Gte(entry => entry.Timestamp, startDate);
+            {
+                var utcStart = startDate.Value.ToUniversalTime();
+                builder &= Builders<MongoDbLogModel>.Filter.Gte(entry => entry.UtcTimeStamp, utcStart);
+            }
 
             if (endDate != null)
-                builder &= Builders<MongoDbLogModel>.Filter.Lte(entry => entry.Timestamp, endDate);
+            {
+                var utcEnd = endDate.Value.ToUniversalTime();
+                builder &= Builders<MongoDbLogModel>.Filter.Lte(entry => entry.UtcTimeStamp, utcEnd);
+            }
         }
     }
 }

--- a/src/Serilog.Ui.Web/Serilog.Ui.Web.csproj
+++ b/src/Serilog.Ui.Web/Serilog.Ui.Web.csproj
@@ -24,4 +24,10 @@
 	<ItemGroup>
 		<ProjectReference Include="..\Serilog.Ui.Core\Serilog.Ui.Core.csproj" />
 	</ItemGroup>
+
+	<ItemGroup>
+	  <EmbeddedResource Update="wwwroot\dist\index.html">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	  </EmbeddedResource>
+	</ItemGroup>
 </Project>

--- a/src/Serilog.Ui.Web/SerilogUiMiddleware.cs
+++ b/src/Serilog.Ui.Web/SerilogUiMiddleware.cs
@@ -11,7 +11,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Serilog.Ui.Core;
 using System;
-using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -154,11 +154,8 @@ namespace Serilog.Ui.Web
             int.TryParse(pageStr, out var currentPage);
             int.TryParse(countStr, out var count);
 
-            DateTime.TryParse(startDateStar, out var startDate);
-            DateTime.TryParse(endDateStar, out var endDate);
-
-            if (endDate != default)
-                endDate = new DateTime(endDate.Year, endDate.Month, endDate.Day, 23, 59, 59);
+            DateTime.TryParse(startDateStar, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out var startDate);
+            DateTime.TryParse(endDateStar, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out var endDate);
 
             currentPage = currentPage == default ? 1 : currentPage;
             count = count == default ? 10 : count;
@@ -166,7 +163,6 @@ namespace Serilog.Ui.Web
             var provider = httpContext.RequestServices.GetService<IDataProvider>();
             var (logs, total) = await provider.FetchDataAsync(currentPage, count, levelStr, searchStr,
                 startDate == default ? (DateTime?)null : startDate, endDate == default ? (DateTime?)null : endDate);
-            //var result = JsonSerializer.Serialize(logs, _jsonSerializerOptions);
             var result = JsonConvert.SerializeObject(new { logs, total, count, currentPage }, _jsonSerializerOptions);
             return result;
         }

--- a/tests/Serilog.Ui.Common.Tests/Serilog.Ui.Common.Tests.csproj
+++ b/tests/Serilog.Ui.Common.Tests/Serilog.Ui.Common.Tests.csproj
@@ -17,7 +17,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />
 		<PackageReference Include="MySql.Data" Version="8.0.23" />
 		<PackageReference Include="Npgsql" Version="6.0.9" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
 		<PackageReference Include="Serilog" Version="2.12.0" />
 		<PackageReference Include="Testcontainers" Version="3.0.0" />
 		<PackageReference Include="xunit.extensibility.core" Version="2.4.2" />

--- a/tests/Serilog.Ui.MongoDbProvider.Tests/Util/Builders/MongoDbDataProviderBuilder.cs
+++ b/tests/Serilog.Ui.MongoDbProvider.Tests/Util/Builders/MongoDbDataProviderBuilder.cs
@@ -1,4 +1,6 @@
-﻿using MongoDB.Driver;
+﻿using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver;
 using Serilog.Ui.Common.Tests.DataSamples;
 using Serilog.Ui.MongoDbProvider;
 using System.Threading.Tasks;
@@ -28,6 +30,15 @@ namespace MongoDb.Tests.Util.Builders
         public static async Task<LogModelPropsCollector> Seed(IMongoCollection<MongoDbLogModel> collection)
         {
             var (array, collector) = MongoDbLogModelFaker.Logs(100);
+
+            // https://stackoverflow.com/a/75637412/15129749
+            var objectSerializer = new ObjectSerializer(type => ObjectSerializer.DefaultAllowedTypes(type) || 
+                type.FullName.StartsWith("Serilog.Ui.Common.Tests") ||
+                type.FullName.StartsWith("MongoDB.Bson.BsonDocument")
+
+                );
+            BsonSerializer.RegisterSerializer(objectSerializer);
+
             await collection.InsertManyAsync(array);
             return collector;
         }


### PR DESCRIPTION
Hi @mo-esmp,

this PR aims to improve the date-time management in the serilog-ui middleware.

- removed in the middleware the endDate manipulation, as the UI now has selectable date & time
- identify the parsed dates as Local (based on the input received from the UI)
- updated MongoDbDataProvider to use UtcTimeStamp, since the TimeStamp provider is empty until model normalization
- (chore) remove npm i target from Serilog.Ui.Web, due to VS issues with locking files. The packages installation will be issued manually by the dev on the first run 👍 