### PR TITLE
fix(web): auto-npm-build only on release

### DIFF
--- a/src/Serilog.Ui.Web/Serilog.Ui.Web.csproj
+++ b/src/Serilog.Ui.Web/Serilog.Ui.Web.csproj
@@ -17,7 +17,7 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	</ItemGroup>
 
-	<Target Name="NpmRunBuild" BeforeTargets="BeforeBuild">
+	<Target Name="NpmRunBuild" BeforeTargets="BeforeBuild" Condition="'$(Configuration)'!='DEBUG'">
 		<Exec Command="npm run build" />
 	</Target>
 


### PR DESCRIPTION
# Scope

Exec npm build on .sln build only on release target.

## Fixes

Prevent ```npm build``` from running on every solution build. 

This will assume that, on local/debug development, any npm build will be triggered manually.