### PR TITLE
perf/idataprovider-extensions

### DIFF
--- a/src/Serilog.Ui.Core/IDataProvider.cs
+++ b/src/Serilog.Ui.Core/IDataProvider.cs
@@ -19,7 +19,7 @@ namespace Serilog.Ui.Core
         /// <param name="startDate">The start date to filter log.</param>
         /// <param name="endDate">The end date to filter log.</param>
         /// <returns>Task&lt;System.ValueTuple&lt;IEnumerable&lt;LogModel&gt;, System.Int32&gt;&gt;.</returns>
-        Task<(IEnumerable<LogModel>, int)> FetchDataAsync(
+        Task<(IEnumerable<LogModel> Logs, int Count)> FetchDataAsync(
             int page,
             int count,
             string level = null,

--- a/src/Serilog.Ui.MongoDbProvider/MongoDbDataProvider.cs
+++ b/src/Serilog.Ui.MongoDbProvider/MongoDbDataProvider.cs
@@ -1,4 +1,5 @@
-﻿using MongoDB.Driver;
+﻿using Ardalis.GuardClauses;
+using MongoDB.Driver;
 using Serilog.Ui.Core;
 using System;
 using System.Collections.Generic;
@@ -13,14 +14,13 @@ namespace Serilog.Ui.MongoDbProvider
 
         public MongoDbDataProvider(IMongoClient client, MongoDbOptions options)
         {
-            if (client is null) throw new ArgumentNullException(nameof(client));
-            if (options is null) throw new ArgumentNullException(nameof(options));
+            Guard.Against.Null(client, nameof(client));
+            Guard.Against.Null(options, nameof(options));
 
             _collection = client.GetDatabase(options.DatabaseName).GetCollection<MongoDbLogModel>(options.CollectionName);
-            var s = _collection.CollectionNamespace;
         }
 
-        public async Task<(IEnumerable<LogModel>, int)> FetchDataAsync(
+        public async Task<(IEnumerable<LogModel> Logs, int Count)> FetchDataAsync(
             int page,
             int count,
             string level = null,
@@ -28,12 +28,12 @@ namespace Serilog.Ui.MongoDbProvider
             DateTime? startDate = null,
             DateTime? endDate = null)
         {
-            var logsTask = await GetLogsAsync(page - 1, count, level, searchCriteria, startDate, endDate);
-            var logCountTask = await CountLogsAsync(level, searchCriteria, startDate, endDate);
+            var logsTask = GetLogsAsync(page - 1, count, level, searchCriteria, startDate, endDate);
+            var logCountTask = CountLogsAsync(level, searchCriteria, startDate, endDate);
 
-            //await Task.WhenAll(logsTask, logCountTask);
+            await Task.WhenAll(logsTask, logCountTask);
 
-            return (logsTask, logCountTask);
+            return (logsTask.Result, logCountTask.Result);
         }
 
         private async Task<IEnumerable<LogModel>> GetLogsAsync(

--- a/src/Serilog.Ui.MongoDbProvider/MongoDbLogModel.cs
+++ b/src/Serilog.Ui.MongoDbProvider/MongoDbLogModel.cs
@@ -22,7 +22,7 @@ namespace Serilog.Ui.MongoDbProvider
         [BsonDateTimeOptions(Kind = DateTimeKind.Local)]
         public DateTime? Timestamp { get; set; }
 
-        [BsonDateTimeOptions(Kind = DateTimeKind.Local)]
+        [BsonDateTimeOptions(Kind = DateTimeKind.Utc)]
         public DateTime UtcTimeStamp { get; set; }
 
         [BsonElement("Exception")]

--- a/src/Serilog.Ui.MongoDbProvider/MongoDbOptions.cs
+++ b/src/Serilog.Ui.MongoDbProvider/MongoDbOptions.cs
@@ -7,5 +7,7 @@
         public string DatabaseName { get; set; }
 
         public string CollectionName { get; set; }
+
+        public bool UseLinq3 { get; set; }
     }
 }

--- a/src/Serilog.Ui.MongoDbProvider/Serilog.Ui.MongoDbProvider.csproj
+++ b/src/Serilog.Ui.MongoDbProvider/Serilog.Ui.MongoDbProvider.csproj
@@ -6,8 +6,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="MongoDB.Driver" Version="2.11.5" />
+		<PackageReference Include="MongoDB.Driver" Version="2.17.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	</ItemGroup>
 


### PR DESCRIPTION
# Scope

Review IDataProviders extensions methods and apply some small cleanups.

## New features

- create new IServiceProvider extensions to let users provide the configuration object
- add UseLinq3 boolean option to enable its usage in the MongoDB SDK
- use Ardalis.Guard.Clauses for the null guards

## Fixes

- bump MongoDB driver package
- name the IDataProvider return tuple 
- use Task.WhenAll on IDataProvider implementation
- TimeStampUtc property in MongoDBLogModel => use BsonKind UTC