### PR TITLE
Put schema and table names enclosed in double quotes

### DIFF
--- a/src/Serilog.Ui.PostgreSqlProvider/PostgreDataProvider.cs
+++ b/src/Serilog.Ui.PostgreSqlProvider/PostgreDataProvider.cs
@@ -79,10 +79,11 @@ namespace Serilog.Ui.PostgreSqlProvider
             DateTime? endDate = null)
         {
             var queryBuilder = new StringBuilder();
-            queryBuilder.Append("SELECT COUNT(message) FROM ");
+            queryBuilder.Append("SELECT COUNT(message) FROM \"");
             queryBuilder.Append(_options.Schema);
-            queryBuilder.Append(".");
+            queryBuilder.Append("\".\"");
             queryBuilder.Append(_options.TableName);
+            queryBuilder.Append("\"");
 
             GenerateWhereClause(queryBuilder, level, searchCriteria, startDate, endDate);
 

--- a/src/Serilog.Ui.PostgreSqlProvider/PostgreDataProvider.cs
+++ b/src/Serilog.Ui.PostgreSqlProvider/PostgreDataProvider.cs
@@ -43,10 +43,11 @@ namespace Serilog.Ui.PostgreSqlProvider
             DateTime? endDate)
         {
             var queryBuilder = new StringBuilder();
-            queryBuilder.Append("SELECT message, message_template, level, timestamp, exception, log_event AS \"Properties\" FROM ");
+            queryBuilder.Append("SELECT message, message_template, level, timestamp, exception, log_event AS \"Properties\" FROM \"");
             queryBuilder.Append(_options.Schema);
-            queryBuilder.Append(".");
+            queryBuilder.Append("\".\"");
             queryBuilder.Append(_options.TableName);
+            queryBuilder.Append("\"");
 
             GenerateWhereClause(queryBuilder, level, searchCriteria, startDate, endDate);
 


### PR DESCRIPTION
SELECT queries fails in PostgreSql if table and/or schema names contains uppercase letters and are not enclosed in double quotes.