### PR TITLE
chore: update readme and repo guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/workflows/DotNET-build.yml
+++ b/.github/workflows/DotNET-build.yml
@@ -47,11 +47,8 @@ jobs:
           SonarToken: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: phoenix-actions/test-reporting@v9
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: DotNET - Tests
-          output-to: checks
+          name: test-results
           path: '**/test-results.trx'
-          reporter: dotnet-trx
-          fail-on-error: false

--- a/.github/workflows/DotNET-reporting-on-build.yml
+++ b/.github/workflows/DotNET-reporting-on-build.yml
@@ -1,0 +1,24 @@
+name: DotNET Test Reporting
+
+# read-write repo token
+# access to secrets
+on:
+  workflow_run:
+    workflows: ['DotNET-build']
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+    - uses: phoenix-actions/test-reporting@v9
+      with:
+        artifact: test-results            # artifact name
+        name: DotNET - Tests              # Name of the check run which will be created
+        path: '**/test-results.trx'       # Path to test results (inside artifact .zip)
+        reporter: dotnet-trx              # Format of test results
+        output-to: checks

--- a/.github/workflows/JS-build.yml
+++ b/.github/workflows/JS-build.yml
@@ -49,14 +49,13 @@ jobs:
 
       - name: SonarCloud run
         uses: SonarSource/sonarcloud-github-action@master
-        if: ${{ false }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_UI }}
         with:
           args: >
-            -Dsonar.organization=
-            -Dsonar.projectKey=
+            -Dsonar.organization=followynne
+            -Dsonar.projectKey=followynne_serilog-ui_assets
             -Dsonar.sources=src/Serilog.Ui.Web/assets/
             -Dsonar.tests=src/Serilog.Ui.Web/assets/
             -Dsonar.exclusions=src/Serilog.Ui.Web/assets/__tests__/**/*

--- a/.github/workflows/JS-build.yml
+++ b/.github/workflows/JS-build.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: SonarCloud run
         uses: SonarSource/sonarcloud-github-action@master
+        if: needs.pr-check.outputs.number == 'null'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_UI }}
@@ -62,11 +63,8 @@ jobs:
             -Dsonar.test.inclusions=src/Serilog.Ui.Web/assets/__tests__/**/*
             -Dsonar.javascript.lcov.reportPaths=./src/Serilog.Ui.Web/coverage/lcov.info
 
-      - uses: phoenix-actions/test-reporting@v9
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: JS - Tests
-          output-to: checks
+          name: test-results
           path: '**/jest-*.xml'
-          reporter: jest-junit
-          fail-on-error: false

--- a/.github/workflows/JS-reporting-on-build.yml
+++ b/.github/workflows/JS-reporting-on-build.yml
@@ -1,0 +1,24 @@
+name: JS Test Reporting
+
+# read-write repo token
+# access to secrets
+on:
+  workflow_run:
+    workflows: ['JS-build']
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+    - uses: phoenix-actions/test-reporting@v9
+      with:
+        artifact: test-results            # artifact name
+        name: JS - Tests                  # Name of the check run which will be created
+        path: '**/jest-*.xml'             # Path to test results (inside artifact .zip)
+        reporter: jest-junit              # Format of test results
+        output-to: checks

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -78,14 +78,13 @@ jobs:
 
       - name: SonarCloud run
         uses: SonarSource/sonarcloud-github-action@master
-        if: ${{ false }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_UI }}
         with:
           args: >
-            -Dsonar.organization=
-            -Dsonar.projectKey=
+            -Dsonar.organization=followynne
+            -Dsonar.projectKey=followynne_serilog-ui_assets
             -Dsonar.sources=src/Serilog.Ui.Web/assets/
             -Dsonar.tests=src/Serilog.Ui.Web/assets/
             -Dsonar.exclusions=src/Serilog.Ui.Web/assets/__tests__/**/*

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -78,6 +78,7 @@ jobs:
 
       - name: SonarCloud run
         uses: SonarSource/sonarcloud-github-action@master
+        if: needs.pr-check.outputs.number == 'null'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_UI }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+## Issues
+
+Issues are very valuable to this project.
+
+  - Ideas are a valuable source of contributions others can make
+  - Problems show where this project is lacking
+  - With a question you show where contributors can improve the user
+    experience
+
+Thank you for creating them.
+
+The project mantainers will try to answer you as soon as possible, please be patient while waiting for an answer 🙂
+
+When possible, use the available templates to write your ideas.
+
+## Pull Requests
+
+Pull requests are a great way to get your features/fix into this repository.
+
+Anyone is more than welcome to propose changes to the source code; the maintainers will try to follow up and review the proposal. After the changes are reviewed and approved, the PR will be merged.
+
+Keep in mind that a Pull Request, to be merged, needs to respect the following things:
+
+### State intent
+
+It should be clear which problem you're trying to solve with your
+contribution.
+
+Please include a detailed description of what you want to achieve, to help the reviewers understand the context of your work 🤝.
+
+### Be of good quality
+
+  - There are no spelling mistakes 📶
+  - It reads well 📖
+  - Repository style is followed ⛏️
+
+### Prepare wiki/README contribution 📋
+
+The project has a wiki where are stored detailed information on how to use the package.
+
+Please keep in mind that it's nice to included, in the description or in a separate comment, the .md content that can be added to the wiki.
+
+With this addtion, reviewers will be able to plan the feature presentation to the end users. 
+
+# Attribution
+
+> The Contributing template was adapted from:
+>
+> [github/PurpleBooth/a-good-readme-template]([https://gist.github.com/PurpleBooth/b24679402957c63ec426](https://github.com/PurpleBooth/a-good-readme-template/blob/main/CONTRIBUTING.md))

--- a/README.md
+++ b/README.md
@@ -1,58 +1,72 @@
-# serilog-ui
-A simple Serilog log viewer for following sinks:
-- [Serilog.Sinks.MSSqlServer](https://github.com/serilog/serilog-sinks-mssqlserver)
-- [Serilog.Sinks.MySql](https://github.com/TeleSoftas/serilog-sinks-mariadb)
-- [Serilog.Sinks.Postgresql](https://github.com/b00ted/serilog-sinks-postgresql)
-- [Serilog.Sinks.MongoDB](https://github.com/serilog/serilog-sinks-mongodb)
-- [Serilog.Sinks.ElasticSearch](https://github.com/serilog/serilog-sinks-elasticsearch)
+# serilog-ui ![GitHub release (latest by date)](https://img.shields.io/github/v/release/serilog-contrib/serilog-ui?label=latest%20release) [![](https://img.shields.io/nuget/dt/serilog.ui.svg?label=nuget%20downloads)](Serilog.UI)
 
-![serilog ui](https://raw.githubusercontent.com/mo-esmp/serilog-ui/master/assets/serilog-ui.jpg)
+[![DotNET-build](https://github.com/serilog-contrib/serilog-ui/actions/workflows/DotNET-build.yml/badge.svg?branch=master)](https://github.com/serilog-contrib/serilog-ui/actions/workflows/DotNET-build.yml)
+[![DotNET Coverage](https://sonarcloud.io/api/project_badges/measure?project=followynne_serilog-ui&metric=coverage)](https://sonarcloud.io/summary/new_code?id=followynne_serilog-ui)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=followynne_serilog-ui&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=followynne_serilog-ui)
 
-Install the _Serilog.UI_ [NuGet package](https://www.nuget.org/packages/Serilog.UI)
+[![JS-build](https://github.com/serilog-contrib/serilog-ui/actions/workflows/JS-build.yml/badge.svg?branch=master)](https://github.com/serilog-contrib/serilog-ui/actions/workflows/JS-build.yml)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=followynne_serilog-ui_assets&metric=coverage)](https://sonarcloud.io/summary/new_code?id=followynne_serilog-ui_assets)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=followynne_serilog-ui_assets&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=followynne_serilog-ui_assets)
+
+A simple Serilog log viewer for the following sinks:
+
+- Serilog.Sinks.**MSSqlServer** ([Nuget](https://github.com/serilog/serilog-sinks-mssqlserver))
+- Serilog.Sinks.**MySql** ([Nuget](https://github.com/TeleSoftas/serilog-sinks-mariadb))
+- Serilog.Sinks.**Postgresql** ([Nuget](https://github.com/b00ted/serilog-sinks-postgresql))
+- Serilog.Sinks.**MongoDB** ([Nuget](https://github.com/serilog/serilog-sinks-mongodb))
+- Serilog.Sinks.**ElasticSearch** ([Nuget](https://github.com/serilog/serilog-sinks-elasticsearch))
+
+<img src="https://raw.githubusercontent.com/mo-esmp/serilog-ui/master/assets/serilog-ui.jpg" width="100%" />
+
+
+# Read the [Wiki :blue_book:](https://github.com/serilog-contrib/serilog-ui/wiki)
+
+## Quick Start :dash:
+
+### Nuget packages installation
+
+Install the _Serilog.UI_ [NuGet package](https://www.nuget.org/packages/Serilog.UI):
+
 ```powershell
+# using dotnet cli
+dotnet add package Serilog.UI
+
+# using package manager:
 Install-Package Serilog.UI
 ```
 
-Then install one of the providers based upon your sink:
+Install one of the available providers, based upon your sink:
 
-| Provider Name                    | Install                                           | Package                                                                          |
-| -------------------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------- |
-| Serilog.UI.MsSqlServerProvider   | `Install-Package Serilog.UI.MsSqlServerProvider`  | [NuGet package](https://www.nuget.org/packages/Serilog.UI.MsSqlServerProvider)   |
-| Serilog.UI.MySqlProvider         | `Install-Package Serilog.UI.MySqlProvider`        | [NuGet package](https://www.nuget.org/packages/Serilog.UI.MySqlProvider)         |
-| Serilog.UI.PostgreSqlProvider    | `Install-Package Serilog.UI.PostgreSqlProvider`   | [NuGet package](https://www.nuget.org/packages/Serilog.UI.PostgreSqlProvider)    |
-| Serilog.UI.MongoDbProviderr      | `Install-Package Serilog.UI.MongoDbProvider`      | [NuGet package](https://www.nuget.org/packages/Serilog.UI.MongoDbProvider)       |
-| Serilog.UI.ElasticSearchProvider | `Install-Package Serilog.UI.ElasticSearcProvider` | [NuGet package](https://www.nuget.org/packages/Serilog.UI.ElasticSearchProvider) |
+| Provider | install: dotnet | install: pkg manager |
+| --- | --- | --- |
+| **Serilog.UI.MsSqlServerProvider** [[NuGet](https://www.nuget.org/packages/Serilog.UI.MsSqlServerProvider)] | `dotnet add package Serilog.UI.MsSqlServerProvider` | `Install-Package Serilog.UI.MsSqlServerProvider` |
+| **Serilog.UI.MySqlProvider** [[NuGet](https://www.nuget.org/packages/Serilog.UI.MySqlProvider)] | `dotnet add package Serilog.UI.MySqlProvider` | `Install-Package Serilog.UI.MySqlProvider` |
+| **Serilog.UI.PostgreSqlProvider** [[NuGet](https://www.nuget.org/packages/Serilog.UI.PostgreSqlProvider)] | `dotnet add package Serilog.UI.PostgreSqlProvider` | `Install-Package Serilog.UI.PostgreSqlProvider` |
+| **Serilog.UI.MongoDbProvider** [[NuGet](https://www.nuget.org/packages/Serilog.UI.MongoDbProvider)] | `dotnet add package Serilog.UI.MongoDbProvider` | `Install-Package Serilog.UI.MongoDbProvider` |
+| **Serilog.UI.ElasticSearchProvider** [[NuGet](https://www.nuget.org/packages/Serilog.UI.ElasticSearchProvider)] | `dotnet add package Serilog.UI.ElasticSearchProvider` | `Install-Package Serilog.UI.ElasticSearcProvider` |
 
-Then, add `AddSerilogUi()` to `IServiceCollection` in `Startup.ConfigureServices` method:
+### DI registration
+
+Add `AddSerilogUi()` to `IServiceCollection` in your `Startup.ConfigureServices` method:
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
     // Register the serilog UI services
-    services.AddSerilogUi(options => options.UseSqlServer("ConnectionString", "LogTableName"));
+    services.AddSerilogUi(options => 
+      // each provider exposes extension methods to configure.
+      // example with MSSqlServerProvider:
+      options.UseSqlServer("ConnectionString", "LogTableName"));
 }
 ```
 
-If you have more than one log table on the database, you add them:
-```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-    services.AddSerilogUi(options => options
-        .UseSqlServer(Configuration.GetConnectionString("DefaultConnection"), "Logs")
-        .UseSqlServer(Configuration.GetConnectionString("DefaultConnection"), "Logs2")
-    );
-}
-```
-This feature is not supported by NoSQL data providers and is limited to `MsSqlServerProvider`, `MySqlProvider` and `PostgreSqlProvider`.
-
-In the `Startup.Configure` method, enable the middleware for serving the log UI. Place a call to the `UseSerilogUi` middleware after authentication and authorization middlewares, otherwise authentication may not work for you:
+In the `Startup.Configure` method, enable the middleware to serve the log UI pagee. 
+Note: call to the `UseSerilogUi` middleware must be placed **_after_** any Authentication and Authorization middleware, otherwise the authentication may not work:
 
 ```csharp
 public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 {
-    .
-    .
-    .
+    (...)
 
     app.UseRouting();
     app.UseAuthentication();
@@ -60,6 +74,8 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         
     // Enable middleware to serve log-ui (HTML, JS, CSS, etc.).
     app.UseSerilogUi();
+
+    (...)
 
     app.UseEndpoints(endpoints =>
     {
@@ -70,191 +86,14 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 }
 ```
 
-## Options
-Options can be found in the [UIOptions](src/Serilog.Ui.Web/Extensions/UiOptions.cs) class.
-`internal` properties can generally be set via extension methods, see [SerilogUiOptionBuilderExtensions](src/Serilog.Ui.Web/Extensions/SerilogUiOptionBuilderExtensions.cs)
+### For further configuration: [:fast_forward:](https://github.com/serilog-contrib/serilog-ui/wiki/Install:-Configuration-Options)
 
-### Authorization
+## Running the Tests: [:test_tube:](https://github.com/serilog-contrib/serilog-ui/wiki/Development:-Testing)
 
-By default serilog-ui allows access to the log page only for local requests. In order to give appropriate rights for production use, you need to configure authorization. You can add your own implementations of the `IUiAuthorizationFilter` interface, whose Authorize method is used to allow or prohibit a request. The first step is to provide your own implementation:
+## License
 
-```csharp
-public void Configure(IApplicationBuilder appBuilder)
-{
-    appBuilder.UseSerilogUi(options =>
-    {
-        options.Authorization.AuthenticationType = AuthenticationType.Jwt;
-        options.Authorization.Filters = new[]
-        {
-            new CustomAuthorizeFilter()
-        };
-    });
-    // ...
-}
-```
+See [LICENSE](https://github.com/serilog-contrib/serilog-ui/blob/master/LICENSE).
 
-If you set `AuthenticationType` to `Jwt`, you can set a JWT token and an `Authorization` header will be added to the request and for `Cookie` just login into your website and no extra step is required.
+## Issues and Contribution
 
-Here is an example of how you can implement your own authentication and authorization:
-
-``` csharp
-public class CustomAuthorizeFilter : IUiAuthorizationFilter
-{
-    public bool Authorize(HttpContext httpContext)
-    {
-        // Allow all authenticated users to see the Dashboard (potentially dangerous).
-        return httpContext.User.Identity is { IsAuthenticated: true };
-    }
-}
-```
-
-### Log page URL
-
-The default url to view the log page is `http://<your-app>/serilog-ui`. If you want to change this url path, just configure the route prefix:
-
-```csharp
-app.UseSerilogUi(option => option.RoutePrefix = "logs");
-```
-
-### Home url
-![image](https://user-images.githubusercontent.com/8641495/185874822-1d4b6f52-864c-4ffb-9064-6fc5ee9a079c.png)
-
-The home button url can be customized by setting the `HomeUrl` property.
-
-``` csharp
-app.UseSerilogUi(options =>
-{
-    options.HomeUrl = "https://example.com/example?q=example";
-});
-```
-
-### Inject custom Javascript and CSS
-
-For customization of the dashboard UI, custom JS and CSS can be injected. 
-
-CSS gets injected in the `<head>` element.
-
-JS gets injected at the end of the `<body>` element by default. 
-
-To inject JS in the `<head>` element set `injectInHead` to `true`.
-
-``` csharp
-app.UseSerilogUi(x =>
-{
-    x.InjectJavascript(path: "/js/serilog-ui/custom.js", injectInHead: false, type: "text/javascript");
-    x.InjectStylesheet(path: "/css/serilog-ui/custom.css", media: "screen");
-});
-```
-
-Custom JS/CSS files must be served by the backend via [static file middleware](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/static-files).
-
-``` csharp
-var builder = WebApplication.CreateBuilder(args);
-...
-app.UseStaticFiles();
-...
-```
-
-With the default configuration static files are served under the wwwroot folder, so in the example above the file structure should be:
-
-![image](https://user-images.githubusercontent.com/8641495/185877921-99aaf19a-3e62-4ad9-85c3-47994e7e6ba1.png)
-
-JS code can be ran when loading the file by wrapping the code in a function, and directly running that function like so:
-``` js
-(function () {
-    console.log("custom.js is loaded.");
-})();
-```
-
-## UI: Frontend development
-
-The serilog-ui frontend is located inside the Serilog.Ui.Web package.
-
-Under the assets/ folder you can find all the relative files. 
-
-The serilog-ui frontend is written in Typescript and built through [ParcelJS](https://parceljs.org/).  
-***Requirement***: Node.js > 16  
-Please run ```npm i``` to install all dependencies!
-
-There are two Grunt tasks you can use to build the frontend project:
-
-- **build**: it cleans wwwroot/dist/ and creates a production-ready build.
-  This build can be used to either:
-  - test the frontend development with the SampleWebApp
-  - create a new production build, by committing the entire wwwroot/dist folder changes  
-- **dev**: it cleans wwwroot/dev/ and starts a dev server to https://127.0.0.1/serilog-ui/  
-  please notice that the development build uses [msw](https://mswjs.io/) to swap any serilog-ui fetch with a mocked version.  
-  You can check details by reading ```assets/script/mocks/fetchMock.ts```.  
-
-<details>
-  <summary>Expand to read additional instructions</summary>
-  
-  Open solution with Visual Studio, to enable easier integration  
-  right click on src/Serilog.Ui.Web/Grunfile.js => open "Task Runner Explorer"
-
-  In the Task Explorer, double click on the Alias Tasks **dev**  
-  You'll see the task starting Parcel task and staying in watch mode, with an output similar to:
-
-  ```
-  Server running at https://127.0.0.1:1234
-  Building...
-  Bundling...
-  Packaging & Optimizing...
-  √ Built in 2.84s
-  ```
-
-  When developing the assets (without the Serilog Middleware), no VS start is needed; Parcel starts a dev server with all you need for the assets part.  
-  All fetches are mocked with MSW to serve fake data (saved in ***mocks/samples.ts***); this helps an user develop the assets without having to worry about creating actual data.
-
-  You can open either https://localhost:1234 or https://127.0.0.1:1234 to work.
-</details>
-
-**please notice that you'll need to accept Parcel https self-signed certificate, otherwise msw service-worker won't be able to connect.**  
-[Parcel related issue](https://github.com/parcel-bundler/parcel/issues/1746), [How to do it - example](https://www.pico.net/kb/how-do-you-get-chrome-to-accept-a-self-signed-certificate/
-
-<details>
-  <summary>If you see an https error (untrusted certificate) while developing with Parcel</summary>
-
-  for Chrome:
-  - click on Not Secure (next to the URL) => click Certificate is not valid => click Details => Copy To File => export the cert as DER Encoded Binary X.509 .cer
-  - go to: chrome://settings/security => click Manage Certificates => go to Trusted Root Certification Authorities tab => import the .cer file previously exported
-  - restart Chrome
-  - you should be able to run the dev environment on both localhost and 127.0.0.1 (to check if it's working fine, open the console: you'll find a red message: **"[MSW] Mocking enabled."**)
-</details>
-
-# Known Limitations
-* Additional columns are not supported and only main columns can be retrieved.
-
-# Test
-
-## .NET Serilog.UI Projects
-
-The test projects are located inside the */tests* folder.
-
-Each Serilog.Ui project has a separate test project.
-Each project is based onto the **xUnit** test framework.
-
-**Serilog.Ui.Common.Tests**: contains anything that can be shared between the tests projects.
-
-To run the tests, use Test Explorer in Visual Studio or run from the root folder:
-
-```
-dotnet test
-```
-
-Please notice: to run the tests, you'll need a running Docker instance on your sistem.  
-Integration tests (identified by traits) on MS Sql, MySql, Postgres, use Docker to spin the integration database.
-
-## JS UI assets
-
-Tests are located inside src/Serilog.Ui.Web/assets/__tests__
-
-Tests are based onto Jest test framework, with the help of JSDOM and testing-library packages. Any HTTP request is mocked through [msw](https://mswjs.io/).
-
-Jest configuration can be found in src/Serilog.Ui.Web/jest.config.js; any additional setup item is located inside src/Serilog.Ui.Web/assets/__tests__/util (this folder is excluded from test runs).
-
-To run the tests, open a terminal in src/Serilog.Ui.Web/ and launch this command (watch-mode):
-
-```
-npm test
-```
+Everything is welcome! :trophy: See the [contribution guidelines](https://github.com/serilog-contrib/serilog-ui/blob/master/CONTRIBUTING.md) for details.

--- a/build/CustomGithubActionsAttribute.cs
+++ b/build/CustomGithubActionsAttribute.cs
@@ -66,11 +66,6 @@ class GithubActionSonarCloud : GitHubActionsStep
         {
             writer.WriteLine("uses: SonarSource/sonarcloud-github-action@master");
 
-            if (string.IsNullOrWhiteSpace(SonarCloudInfo.FrontendProjectKey))
-            {
-                writer.WriteLine("if: ${{ false }}");
-            }
-
             writer.WriteLine("env:");
             using (writer.Indent())
             {


### PR DESCRIPTION
This PR aims to 😄:

- review & cleaning the README while moving all the details to the [/wiki section](https://github.com/serilog-contrib/serilog-ui/wiki), for better readability and clarity
- create issues templates, to uniform their creation
- create a first Contributing file
- enable sonarcloud scan on frontend project (a small fix I forgot to remove in the prev branch)

I had to do some changes to the build, because I found that PR from forks can't access repo secrets (that's the reason sonar+reporting fails only during PR)...

- I made SonarCloud to run only on build made on the main repo
- I created a sort-of help worflow that, after it's merged on master, will take the test reports as artifacts and publish them using the reporting action. It will work even with PRs (it should work, at least, I think 😄 )

(next step: React! 🔜 )