### PR TITLE
fix(build): missing sonarcloud csharp coverage

### DIFF
--- a/.github/workflows/DotNET-build.yml
+++ b/.github/workflows/DotNET-build.yml
@@ -18,6 +18,7 @@ name: DotNET-build
 
 on:
   workflow_dispatch:
+
   push:
     branches:
       - master
@@ -32,6 +33,11 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -48,7 +54,7 @@ jobs:
           SonarToken: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: test-results

--- a/.github/workflows/DotNET-build.yml
+++ b/.github/workflows/DotNET-build.yml
@@ -17,6 +17,7 @@
 name: DotNET-build
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/DotNET-build.yml
+++ b/.github/workflows/DotNET-build.yml
@@ -17,8 +17,6 @@
 name: DotNET-build
 
 on:
-  workflow_dispatch:
-
   push:
     branches:
       - master

--- a/.github/workflows/JS-build.yml
+++ b/.github/workflows/JS-build.yml
@@ -31,6 +31,11 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -63,7 +68,7 @@ jobs:
             -Dsonar.test.inclusions=src/Serilog.Ui.Web/assets/__tests__/**/*
             -Dsonar.javascript.lcov.reportPaths=./src/Serilog.Ui.Web/coverage/lcov.info
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: test-results

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -43,6 +43,11 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/build/Build.Backend.Tests.cs
+++ b/build/Build.Backend.Tests.cs
@@ -31,6 +31,6 @@ partial class Build : NukeBuild
         .Executes(() =>
         {
             DotnetCoverage?.Invoke(
-                @"collect -f xml -o ""coverage.xml"" dotnet test --configuration Release --no-build --logger=""trx;LogFileName=test-results.trx""");
+                @"collect -f xml -o ""src/coverage.xml"" dotnet test --configuration Release --no-build --logger=""trx;LogFileName=test-results.trx""");
         });
 }

--- a/build/Build.Backend.Tests.cs
+++ b/build/Build.Backend.Tests.cs
@@ -31,6 +31,6 @@ partial class Build : NukeBuild
         .Executes(() =>
         {
             DotnetCoverage?.Invoke(
-                @"collect ""dotnet test --configuration Release --no-build --logger=""trx;LogFileName=test-results.trx"" "" -f xml -o ""coverage.xml""");
+                @"collect -f xml -o ""coverage.xml"" dotnet test --configuration Release --no-build --logger=""trx;LogFileName=test-results.trx""");
         });
 }

--- a/build/Build.Backend.Tests.cs
+++ b/build/Build.Backend.Tests.cs
@@ -31,6 +31,6 @@ partial class Build : NukeBuild
         .Executes(() =>
         {
             DotnetCoverage?.Invoke(
-                @"collect -f xml -o ""coverage.xml"" dotnet test --configuration Release --no-build --logger=""trx;LogFileName=test-results.trx""");
+                @"collect -f xml -o coverage.xml dotnet test --configuration Release --no-build --logger=""trx;LogFileName=test-results.trx""");
         });
 }

--- a/build/Build.Backend.Tests.cs
+++ b/build/Build.Backend.Tests.cs
@@ -31,6 +31,6 @@ partial class Build : NukeBuild
         .Executes(() =>
         {
             DotnetCoverage?.Invoke(
-                @"collect -f xml -o ""src/coverage.xml"" dotnet test --configuration Release --no-build --logger=""trx;LogFileName=test-results.trx""");
+                @"collect -f xml -o ""./coverage.xml"" dotnet test --configuration Release --no-build --logger=""trx;LogFileName=test-results.trx""");
         });
 }

--- a/build/Build.Backend.Tests.cs
+++ b/build/Build.Backend.Tests.cs
@@ -31,6 +31,6 @@ partial class Build : NukeBuild
         .Executes(() =>
         {
             DotnetCoverage?.Invoke(
-                @"collect -f xml -o ""./coverage.xml"" dotnet test --configuration Release --no-build --logger=""trx;LogFileName=test-results.trx""");
+                @"collect ""dotnet test --configuration Release --no-build --logger=""trx;LogFileName=test-results.trx"" "" -f xml -o ""coverage.xml""");
         });
 }

--- a/build/Build.Backend.cs
+++ b/build/Build.Backend.cs
@@ -2,12 +2,10 @@ using Nuke.Common;
 using Nuke.Common.IO;
 using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Utilities.Collections;
-using System.Diagnostics.CodeAnalysis;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 
 partial class Build : NukeBuild
 {
-    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Not necessary")]
     Target Backend_Clean => _ => _
         .Executes(() =>
         {

--- a/build/Build.CI.GithubActions.cs
+++ b/build/Build.CI.GithubActions.cs
@@ -1,11 +1,7 @@
-using NuGet.Common;
 using Nuke.Common;
 using Nuke.Common.CI.GitHubActions;
-using Nuke.Common.IO;
 using Nuke.Common.Tooling;
-using Nuke.Common.Tools.GitHub;
 using Nuke.Common.Tools.SonarScanner;
-using Serilog;
 using static CustomGithubActionsAttribute;
 
 /**
@@ -91,8 +87,7 @@ partial class Build : NukeBuild
             SonarScannerTasks.SonarScannerBegin(new SonarScannerBeginSettings()
                 .SetExcludeTestProjects(true)
                 .SetFramework("net5.0")
-                .SetVerbose(true)
-                .SetAdditionalParameter("sonar.token", SonarToken)
+                .SetAdditionalParameter("sonar.token", SonarToken) // replace deprecated .login
                 .SetOrganization(SonarCloudInfo.Organization)
                 .SetProjectKey(SonarCloudInfo.BackendProjectKey)
                 .SetServer("https://sonarcloud.io")
@@ -103,7 +98,7 @@ partial class Build : NukeBuild
                     "src/Serilog.Ui.Web/node_modules/**/*",
                     "src/Serilog.Ui.Web/*.js",
                     "src/Serilog.Ui.Web/*.json")
-                .SetVisualStudioCoveragePaths("coverage.xml", "**/coverage.xml", "/**/coverage.xml", "./**/coverage.xml",  "serilog-ui/**/coverage.xml")
+                .SetVisualStudioCoveragePaths("coverage.xml", "**/coverage.xml", "./**/coverage.xml")
                 .SetProcessEnvironmentVariable("GITHUB_TOKEN", GitHubActions.Instance.Token)
                 .SetProcessEnvironmentVariable("SONAR_TOKEN", SonarToken)
             );

--- a/build/Build.CI.GithubActions.cs
+++ b/build/Build.CI.GithubActions.cs
@@ -87,10 +87,6 @@ partial class Build : NukeBuild
         )
         .Executes(() =>
         {
-            var res = OutputDirectory.GlobFiles("*.coverage.xml", "coverage.xml");
-            foreach(var p in res){
-                Log.Warning("my @Path", p);
-            }
             SonarScannerTasks.SonarScannerBegin(new SonarScannerBeginSettings()
                 .SetExcludeTestProjects(true)
                 .SetFramework("net5.0")
@@ -99,14 +95,15 @@ partial class Build : NukeBuild
                 .SetOrganization(SonarCloudInfo.Organization)
                 .SetProjectKey(SonarCloudInfo.BackendProjectKey)
                 .SetServer("https://sonarcloud.io")
-                .SetSourceInclusions("src/**/*", "coverage.xml", "**/coverage.xml")
+                .SetSourceInclusions("src/**/*", "src/coverage.xml")
                 .SetSourceExclusions(
                     "src/Serilog.Ui.Web/assets/**/*",
                     "src/Serilog.Ui.Web/wwwroot/**/*",
                     "src/Serilog.Ui.Web/node_modules/**/*",
                     "src/Serilog.Ui.Web/*.js",
                     "src/Serilog.Ui.Web/*.json")
-                .SetVisualStudioCoveragePaths("**/coverage.xml", "coverage.xml", "**/*.coverage.xml", "**/*.xml")
+                .SetVisualStudioCoveragePaths("**/coverage.xml", "coverage.xml")
+                .SetGenericCoveragePaths("**/coverage.xml", "coverage.xml")
                 .SetVerbose(true)
                 .SetProcessEnvironmentVariable("GITHUB_TOKEN", GitHubActions.Instance.Token)
                 .SetProcessEnvironmentVariable("SONAR_TOKEN", SonarToken)

--- a/build/Build.CI.GithubActions.cs
+++ b/build/Build.CI.GithubActions.cs
@@ -114,7 +114,7 @@ partial class Build : NukeBuild
         {
             SonarScannerTasks.SonarScannerEnd(new SonarScannerEndSettings()
                 .SetFramework("net5.0")
-                .SetLogin(SonarToken)
+                .SetProcessArgumentConfigurator(_ => _.Add("/d:sonar.token={value}", SonarToken, secret: true))
                 .SetProcessEnvironmentVariable("GITHUB_TOKEN", GitHubActions.Instance.Token)
                 .SetProcessEnvironmentVariable("SONAR_TOKEN", SonarToken));
         });

--- a/build/Build.CI.GithubActions.cs
+++ b/build/Build.CI.GithubActions.cs
@@ -99,7 +99,7 @@ partial class Build : NukeBuild
                     "src/Serilog.Ui.Web/node_modules/**/*",
                     "src/Serilog.Ui.Web/*.js",
                     "src/Serilog.Ui.Web/*.json")
-                .SetVisualStudioCoveragePaths("**/coverage.xml")
+                .SetVisualStudioCoveragePaths("**/coverage.xml", "coverage.xml")
                 .SetProcessEnvironmentVariable("GITHUB_TOKEN", GitHubActions.Instance.Token)
                 .SetProcessEnvironmentVariable("SONAR_TOKEN", SonarToken)
             );

--- a/build/Build.CI.GithubActions.cs
+++ b/build/Build.CI.GithubActions.cs
@@ -103,7 +103,6 @@ partial class Build : NukeBuild
                     "src/Serilog.Ui.Web/*.js",
                     "src/Serilog.Ui.Web/*.json")
                 .SetVisualStudioCoveragePaths("**/coverage.xml", "coverage.xml")
-                .SetGenericCoveragePaths("**/coverage.xml", "coverage.xml")
                 .SetVerbose(true)
                 .SetProcessEnvironmentVariable("GITHUB_TOKEN", GitHubActions.Instance.Token)
                 .SetProcessEnvironmentVariable("SONAR_TOKEN", SonarToken)

--- a/build/Build.CI.GithubActions.cs
+++ b/build/Build.CI.GithubActions.cs
@@ -90,19 +90,19 @@ partial class Build : NukeBuild
             SonarScannerTasks.SonarScannerBegin(new SonarScannerBeginSettings()
                 .SetExcludeTestProjects(true)
                 .SetFramework("net5.0")
-                .SetAdditionalParameter("token", SonarToken)
+                .SetAdditionalParameter("sonar.token", SonarToken)
                 .SetLogin(SonarToken)
                 .SetOrganization(SonarCloudInfo.Organization)
                 .SetProjectKey(SonarCloudInfo.BackendProjectKey)
                 .SetServer("https://sonarcloud.io")
-                .SetSourceInclusions("src/**/*", "src/coverage.xml")
+                .SetSourceInclusions("src/**/*")
                 .SetSourceExclusions(
                     "src/Serilog.Ui.Web/assets/**/*",
                     "src/Serilog.Ui.Web/wwwroot/**/*",
                     "src/Serilog.Ui.Web/node_modules/**/*",
                     "src/Serilog.Ui.Web/*.js",
                     "src/Serilog.Ui.Web/*.json")
-                .SetVisualStudioCoveragePaths("**/coverage.xml", "coverage.xml")
+                .SetVisualStudioCoveragePaths("coverage.xml")
                 .SetVerbose(true)
                 .SetProcessEnvironmentVariable("GITHUB_TOKEN", GitHubActions.Instance.Token)
                 .SetProcessEnvironmentVariable("SONAR_TOKEN", SonarToken)

--- a/build/Build.CI.GithubActions.cs
+++ b/build/Build.CI.GithubActions.cs
@@ -1,3 +1,4 @@
+using NuGet.Common;
 using Nuke.Common;
 using Nuke.Common.CI.GitHubActions;
 using Nuke.Common.IO;
@@ -102,7 +103,7 @@ partial class Build : NukeBuild
                     "src/Serilog.Ui.Web/node_modules/**/*",
                     "src/Serilog.Ui.Web/*.js",
                     "src/Serilog.Ui.Web/*.json")
-                .SetVisualStudioCoveragePaths("coverage.xml")
+                .SetVisualStudioCoveragePaths("coverage.xml", "**/coverage.xml", "/**/coverage.xml", "./**/coverage.xml",  "serilog-ui/**/coverage.xml")
                 .SetProcessEnvironmentVariable("GITHUB_TOKEN", GitHubActions.Instance.Token)
                 .SetProcessEnvironmentVariable("SONAR_TOKEN", SonarToken)
             );

--- a/build/Build.CI.GithubActions.cs
+++ b/build/Build.CI.GithubActions.cs
@@ -90,8 +90,8 @@ partial class Build : NukeBuild
             SonarScannerTasks.SonarScannerBegin(new SonarScannerBeginSettings()
                 .SetExcludeTestProjects(true)
                 .SetFramework("net5.0")
+                .SetVerbose(true)
                 .SetAdditionalParameter("sonar.token", SonarToken)
-                .SetLogin(SonarToken)
                 .SetOrganization(SonarCloudInfo.Organization)
                 .SetProjectKey(SonarCloudInfo.BackendProjectKey)
                 .SetServer("https://sonarcloud.io")
@@ -103,7 +103,6 @@ partial class Build : NukeBuild
                     "src/Serilog.Ui.Web/*.js",
                     "src/Serilog.Ui.Web/*.json")
                 .SetVisualStudioCoveragePaths("coverage.xml")
-                .SetVerbose(true)
                 .SetProcessEnvironmentVariable("GITHUB_TOKEN", GitHubActions.Instance.Token)
                 .SetProcessEnvironmentVariable("SONAR_TOKEN", SonarToken)
             );

--- a/build/Build.CI.GithubActions.cs
+++ b/build/Build.CI.GithubActions.cs
@@ -92,7 +92,7 @@ partial class Build : NukeBuild
                 .SetOrganization(SonarCloudInfo.Organization)
                 .SetProjectKey(SonarCloudInfo.BackendProjectKey)
                 .SetServer("https://sonarcloud.io")
-                .SetSourceInclusions("src/**/*")
+                .SetSourceInclusions("src/**/*", "coverage.xml", "**/coverage.xml")
                 .SetSourceExclusions(
                     "src/Serilog.Ui.Web/assets/**/*",
                     "src/Serilog.Ui.Web/wwwroot/**/*",

--- a/build/Build.CI.GithubActions.cs
+++ b/build/Build.CI.GithubActions.cs
@@ -1,8 +1,10 @@
 using Nuke.Common;
 using Nuke.Common.CI.GitHubActions;
+using Nuke.Common.IO;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.GitHub;
 using Nuke.Common.Tools.SonarScanner;
+using Serilog;
 using static CustomGithubActionsAttribute;
 
 /**
@@ -85,9 +87,14 @@ partial class Build : NukeBuild
         )
         .Executes(() =>
         {
+            var res = OutputDirectory.GlobFiles("*.coverage.xml", "coverage.xml");
+            foreach(var p in res){
+                Log.Warning("my @Path", p);
+            }
             SonarScannerTasks.SonarScannerBegin(new SonarScannerBeginSettings()
                 .SetExcludeTestProjects(true)
                 .SetFramework("net5.0")
+                .SetAdditionalParameter("token", SonarToken)
                 .SetLogin(SonarToken)
                 .SetOrganization(SonarCloudInfo.Organization)
                 .SetProjectKey(SonarCloudInfo.BackendProjectKey)
@@ -99,7 +106,8 @@ partial class Build : NukeBuild
                     "src/Serilog.Ui.Web/node_modules/**/*",
                     "src/Serilog.Ui.Web/*.js",
                     "src/Serilog.Ui.Web/*.json")
-                .SetVisualStudioCoveragePaths("**/coverage.xml", "coverage.xml")
+                .SetVisualStudioCoveragePaths("**/coverage.xml", "coverage.xml", "**/*.coverage.xml", "**/*.xml")
+                .SetVerbose(true)
                 .SetProcessEnvironmentVariable("GITHUB_TOKEN", GitHubActions.Instance.Token)
                 .SetProcessEnvironmentVariable("SONAR_TOKEN", SonarToken)
             );

--- a/build/Build.Frontend.cs
+++ b/build/Build.Frontend.cs
@@ -4,11 +4,9 @@ using Nuke.Common.Tooling;
 using Nuke.Common.Tools.Docker;
 using Nuke.Common.Tools.Npm;
 using Nuke.Common.Utilities.Collections;
-using System.Diagnostics.CodeAnalysis;
 
 partial class Build : NukeBuild
 {
-    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Not necessary")]
     Target Frontend_Clean => _ => _
         .Executes(() =>
         {

--- a/build/CustomGithubActionsAttribute.cs
+++ b/build/CustomGithubActionsAttribute.cs
@@ -4,6 +4,7 @@ using Nuke.Common.Execution;
 using Nuke.Common.Utilities;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 /// <summary>
 /// from: https://github.com/RicoSuter/NSwag/blob/master/build/Build.CI.GitHubActions.cs
@@ -28,7 +29,7 @@ class CustomGithubActionsAttribute : GitHubActionsAttribute
     protected override GitHubActionsJob GetJobs(GitHubActionsImage image, IReadOnlyCollection<ExecutableTarget> relevantTargets)
     {
         var job = base.GetJobs(image, relevantTargets);
-        var newSteps = new List<GitHubActionsStep>(job.Steps);
+        var newSteps = new List<GitHubActionsStep>(new GitHubActionsStep[] { new GitHubActionSetupJava17() }.Concat(job.Steps));
 
         foreach (var act in AddGithubActions)
         {
@@ -59,6 +60,30 @@ class CustomGithubActionsAttribute : GitHubActionsAttribute
     }
 }
 
+/// <summary>
+/// using: https://github.com/actions/setup-java
+/// </summary>
+class GitHubActionSetupJava17 : GitHubActionsStep
+{
+    public override void Write(CustomFileWriter writer)
+    {
+        writer.WriteLine(); // empty line to separate tasks
+
+        writer.WriteLine("- uses: actions/setup-java@v3");
+
+        using (writer.Indent())
+        {
+            writer.WriteLine("with:");
+
+            using (writer.Indent())
+            {
+                writer.WriteLine($"distribution: 'temurin'");
+                writer.WriteLine($"java-version: '17'");
+            }
+        }
+    }
+}
+
 class GithubActionUploadArtifact : GitHubActionsStep
 {
     readonly string Path;
@@ -72,7 +97,7 @@ class GithubActionUploadArtifact : GitHubActionsStep
     {
         writer.WriteLine(); // empty line to separate tasks
 
-        writer.WriteLine("- uses: actions/upload-artifact@v2");
+        writer.WriteLine("- uses: actions/upload-artifact@v3");
 
         using (writer.Indent())
         {

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -22,6 +22,6 @@
 
 	<ItemGroup>
 		<PackageDownload Include="dotnet-coverage" Version="[17.6.11]" />
-		<PackageDownload Include="dotnet-sonarscanner" Version="[5.12.0]" />
+		<PackageDownload Include="dotnet-sonarscanner" Version="[5.13.1]" />
 	</ItemGroup>
 </Project>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -21,7 +21,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageDownload Include="dotnet-coverage" Version="[17.6.11]" />
+		<PackageDownload Include="dotnet-coverage" Version="[17.8.6]" />
 		<PackageDownload Include="dotnet-sonarscanner" Version="[5.13.1]" />
 	</ItemGroup>
 </Project>

--- a/src/Serilog.Ui.ElasticSearchProvider/Extensions/VanillaSerializer.cs
+++ b/src/Serilog.Ui.ElasticSearchProvider/Extensions/VanillaSerializer.cs
@@ -28,7 +28,7 @@ namespace Serilog.Ui.ElasticSearchProvider
         public Task<object> DeserializeAsync(Type type, Stream stream, CancellationToken cancellationToken = default) =>
             Task.FromResult(Deserialize(type, stream));
 
-        public void Serialize<T>(T data, Stream stream, SerializationFormatting formatting = SerializationFormatting.Indented)
+        public void Serialize<T>(T data, Stream stream, SerializationFormatting formatting = SerializationFormatting.None)
         {
             var writer = new StreamWriter(stream);
 
@@ -45,7 +45,7 @@ namespace Serilog.Ui.ElasticSearchProvider
         public Task SerializeAsync<T>(
             T data,
             Stream stream,
-            SerializationFormatting formatting = SerializationFormatting.Indented,
+            SerializationFormatting formatting = SerializationFormatting.None,
             CancellationToken cancellationToken = default)
         {
             Serialize(data, stream, formatting);


### PR DESCRIPTION
This PR resolves the following:

- missing Sonarcloud Code Coverage for C# code
- upgrade java and github-actions versions
- use sonar.token property instead of deprecated sonar.login
- [fix sonar major issue on Vanilla Serializer](https://sonarcloud.io/project/issues?open=AYb5jXUrOz1K75YHgi8f&id=followynne_serilog-ui)