### PR TITLE
Add Basic Authentication Support to serilog-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,21 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 }
 ```
 
+## Basic Authentication
+
+If you need to add basic authentication to your serilog-ui instance, you can use the `BasicAuthenticationFilter`. Here's how to configure it in your `Startup.Configure` method:
+
+```csharp
+app.UseSerilogUi(options =>
+{
+    options.Authorization.Filters = new IUiAuthorizationFilter[]
+    {
+        new BasicAuthenticationFilter { User = "User", Pass = "P@ss" }
+    };
+    options.Authorization.RunAuthorizationFilterOnAppRoutes = true;
+});
+```
+
 ### For further configuration: [:fast_forward:](https://github.com/serilog-contrib/serilog-ui/wiki/Install:-Configuration-Options)
 
 ## Running the Tests: [:test_tube:](https://github.com/serilog-contrib/serilog-ui/wiki/Development:-Testing)

--- a/src/Serilog.Ui.Web/Authorization/BasicAuthenticationFilter.cs
+++ b/src/Serilog.Ui.Web/Authorization/BasicAuthenticationFilter.cs
@@ -12,7 +12,7 @@ public class BasicAuthenticationFilter : IUiAuthorizationFilter
     public string Pass { get; set; }
 
     private const string AuthenticationScheme = "Basic";
-    private const string AuthenticationCookieName = "SerilogAuth";
+    internal const string AuthenticationCookieName = "SerilogAuth";
 
     public bool Authorize(HttpContext httpContext)
     {
@@ -25,7 +25,7 @@ public class BasicAuthenticationFilter : IUiAuthorizationFilter
             if (!string.IsNullOrWhiteSpace(authCookie))
             {
                 var hashedCredentials = EncryptCredentials(User, Pass);
-                isAuthenticated = string.Equals(authCookie, hashedCredentials, StringComparison.OrdinalIgnoreCase);
+                isAuthenticated = authCookie.Equals(hashedCredentials, StringComparison.OrdinalIgnoreCase);
             }
         }
         else
@@ -53,9 +53,9 @@ public class BasicAuthenticationFilter : IUiAuthorizationFilter
         return isAuthenticated;
     }
 
-    public string EncryptCredentials(string user, string pass)
+    private string EncryptCredentials(string user, string pass)
     {
-        var sha256 = SHA256.Create();
+        using var sha256 = SHA256.Create();
         var hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes($"{user}:{pass}"));
         var hashedCredentials = BitConverter.ToString(hashBytes).Replace("-", "").ToLower();
         return hashedCredentials;
@@ -81,7 +81,7 @@ public class BasicAuthenticationFilter : IUiAuthorizationFilter
     private void SetChallengeResponse(HttpContext httpContext)
     {
         httpContext.Response.StatusCode = 401;
-        httpContext.Response.Headers.Append("WWW-Authenticate", "Basic realm=\"SeriLog Ui\"");
+        httpContext.Response.Headers.Append("WWW-Authenticate", "Basic realm=\"Serilog UI\"");
         httpContext.Response.WriteAsync("Authentication is required.");
     }
 }

--- a/src/Serilog.Ui.Web/Authorization/BasicAuthenticationFilter.cs
+++ b/src/Serilog.Ui.Web/Authorization/BasicAuthenticationFilter.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+
+namespace Serilog.Ui.Web.Authorization;
+
+public class BasicAuthenticationFilter : IUiAuthorizationFilter
+{
+    public string User { get; set; }
+    public string Pass { get; set; }
+
+    private const string AuthenticationScheme = "Basic";
+    private const string AuthenticationCookieName = "SerilogAuth";
+
+    public bool Authorize(HttpContext httpContext)
+    {
+        var header = httpContext.Request.Headers["Authorization"];
+        var isAuthenticated = false;
+
+        if (header == "null" || string.IsNullOrEmpty(header))
+        {
+            var authCookie = httpContext.Request.Cookies[AuthenticationCookieName];
+            if (!string.IsNullOrWhiteSpace(authCookie))
+            {
+                var hashedCredentials = EncryptCredentials(User, Pass);
+                isAuthenticated = string.Equals(authCookie, hashedCredentials, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+        else
+        {
+            var authValues = AuthenticationHeaderValue.Parse(header);
+
+            if (IsBasicAuthentication(authValues))
+            {
+                var tokens = ExtractAuthenticationTokens(authValues);
+
+                if (CredentialsMatch(tokens))
+                {
+                    isAuthenticated = true;
+                    var hashedCredentials = EncryptCredentials(User, Pass);
+                    httpContext.Response.Cookies.Append(AuthenticationCookieName, hashedCredentials);
+                }
+            }
+        }
+
+        if (!isAuthenticated)
+        {
+            SetChallengeResponse(httpContext);
+        }
+
+        return isAuthenticated;
+    }
+
+    public string EncryptCredentials(string user, string pass)
+    {
+        var sha256 = SHA256.Create();
+        var hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes($"{user}:{pass}"));
+        var hashedCredentials = BitConverter.ToString(hashBytes).Replace("-", "").ToLower();
+        return hashedCredentials;
+    }
+
+    private static bool IsBasicAuthentication(AuthenticationHeaderValue authValues)
+    {
+        return AuthenticationScheme.Equals(authValues.Scheme, StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    private static (string, string) ExtractAuthenticationTokens(AuthenticationHeaderValue authValues)
+    {
+        var parameter = Encoding.UTF8.GetString(Convert.FromBase64String(authValues.Parameter));
+        var parts = parameter.Split(':');
+        return (parts[0], parts[1]);
+    }
+
+    private bool CredentialsMatch((string Username, string Password) tokens)
+    {
+        return tokens.Username == User && tokens.Password == Pass;
+    }
+
+    private void SetChallengeResponse(HttpContext httpContext)
+    {
+        httpContext.Response.StatusCode = 401;
+        httpContext.Response.Headers.Append("WWW-Authenticate", "Basic realm=\"SeriLog Ui\"");
+        httpContext.Response.WriteAsync("Authentication is required.");
+    }
+}

--- a/tests/Serilog.Ui.Web.Tests/Authorization/BasicAuthenticationFilterTests.cs
+++ b/tests/Serilog.Ui.Web.Tests/Authorization/BasicAuthenticationFilterTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Net.Http.Headers;
@@ -23,9 +24,11 @@ public class BasicAuthenticationFilterTests
 
         // Act
         var result = filter.Authorize(httpContext);
+        var authCookie = httpContext.Response.GetTypedHeaders().SetCookie.FirstOrDefault(sc => sc.Name == BasicAuthenticationFilter.AuthenticationCookieName);
 
         // Assert
         result.Should().BeTrue();
+        authCookie.Should().NotBeNull();
     }
 
     [Fact]
@@ -66,6 +69,6 @@ public class BasicAuthenticationFilterTests
         // Assert
         result.Should().BeFalse();
         httpContext.Response.StatusCode.Should().Be(401);
-        httpContext.Response.Headers[HeaderNames.WWWAuthenticate].Should().Contain("Basic realm=\"Hangfire Dashboard\"");
+        httpContext.Response.Headers[HeaderNames.WWWAuthenticate].Should().Contain("Basic realm=\"Serilog UI\"");
     }
 }

--- a/tests/Serilog.Ui.Web.Tests/Authorization/BasicAuthenticationFilterTests.cs
+++ b/tests/Serilog.Ui.Web.Tests/Authorization/BasicAuthenticationFilterTests.cs
@@ -1,0 +1,71 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Serilog.Ui.Web.Authorization.Tests;
+
+public class BasicAuthenticationFilterTests
+{
+    [Fact]
+    public async Task Authorize_WithValidCredentials_ShouldReturnTrue()
+    {
+        // Arrange
+        var filter = new BasicAuthenticationFilter
+        {
+            User = "User",
+            Pass = "P@ss"
+        };
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Authorization"] = "Basic VXNlcjpQQHNz"; // Base64 encoded "User:P@ss"
+
+        // Act
+        var result = filter.Authorize(httpContext);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Authorize_WithInvalidCredentials_ShouldReturnFalse()
+    {
+        // Arrange
+        var filter = new BasicAuthenticationFilter
+        {
+            User = "User",
+            Pass = "P@ss"
+        };
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Authorization"] = "Basic QWRtaW46dXNlcg=="; // Base64 encoded "Admin:user"
+
+        // Act
+        var result = filter.Authorize(httpContext);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Authorize_WithMissingAuthorizationHeader_ShouldSetChallengeResponse()
+    {
+        // Arrange
+        var filter = new BasicAuthenticationFilter
+        {
+            User = "User",
+            Pass = "P@ss"
+        };
+
+        var httpContext = new DefaultHttpContext();
+
+        // Act
+        var result = filter.Authorize(httpContext);
+
+        // Assert
+        result.Should().BeFalse();
+        httpContext.Response.StatusCode.Should().Be(401);
+        httpContext.Response.Headers[HeaderNames.WWWAuthenticate].Should().Contain("Basic realm=\"Hangfire Dashboard\"");
+    }
+}


### PR DESCRIPTION
This pull request enhances the serilog-ui project by adding support for basic authentication, allowing users to secure their log viewer with a username and password. This feature is valuable for controlling access to the log viewer, ensuring that only authorized personnel can view and analyze logs.

**Changes Made**:

- Introduced a `BasicAuthenticationFilter` that can be configured to provide basic authentication for serilog-ui.

**Usage**:

To enable basic authentication for serilog-ui, developers can now use the `BasicAuthenticationFilter` by configuring it in their `Startup.Configure` method, as described in the README. 

**Testing**:

Testing has been performed to verify the proper functioning of the basic authentication feature.