### PR TITLE
Fix (#96) improve datetime parsing on sql server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -354,4 +354,8 @@ nuget.exe
 coverage.xml
 coverage/
 
+# Nuke working files
 .nuke/temp/
+
+# JetBrains IDE user folders
+.idea/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,5 +5,9 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="Teronis.MSBuild.Packaging.ProjectBuildInPackage" Version="1.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 </Project>

--- a/samples/SampleWebApp/SampleWebApp.csproj
+++ b/samples/SampleWebApp/SampleWebApp.csproj
@@ -1,32 +1,35 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <UserSecretsId>aspnet-SampleWebApp-93B544DE-DDCF-47C1-AD8A-BC87C4D6B954</UserSecretsId>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <UserSecretsId>aspnet-SampleWebApp-93B544DE-DDCF-47C1-AD8A-BC87C4D6B954</UserSecretsId>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="7.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.10">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
-    <PackageReference Include="Serilog.Formatting.Elasticsearch" Version="8.4.1" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.4.1" />
-    <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="6.3.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-  </ItemGroup>
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute"/>
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.10"/>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.10"/>
+        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.10"/>
+        <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="7.0.10"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.10"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.10">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Serilog.AspNetCore" Version="7.0.0"/>
+        <PackageReference Include="Serilog.Formatting.Elasticsearch" Version="8.4.1"/>
+        <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.1"/>
+        <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0"/>
+        <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.4.1"/>
+        <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="6.3.0"/>
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Serilog.Ui.MsSqlServerProvider\Serilog.Ui.MsSqlServerProvider.csproj" />
-    <ProjectReference Include="..\..\src\Serilog.Ui.Web\Serilog.Ui.Web.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Serilog.Ui.MsSqlServerProvider\Serilog.Ui.MsSqlServerProvider.csproj"/>
+        <ProjectReference Include="..\..\src\Serilog.Ui.Web\Serilog.Ui.Web.csproj"/>
+    </ItemGroup>
 
 </Project>

--- a/src/Serilog.Ui.MsSqlServerProvider/DapperDateTimeHandler.cs
+++ b/src/Serilog.Ui.MsSqlServerProvider/DapperDateTimeHandler.cs
@@ -39,12 +39,12 @@ public class DapperDateTimeHandler : SqlMapper.TypeHandler<DateTime>
 
         if (_dateTimeCustomParsing is not null) return CustomParse(valueStr);
 
-        DateTime.TryParse(valueStr, CultureInfo.CurrentCulture, DateTimeStyles.None, out var timeStamp);
+        DateTime.TryParse(valueStr, CultureInfo.CurrentCulture, DateTimeStyles.AssumeLocal, out var timeStamp);
 
         if (timeStamp == default)
             DateTime.TryParseExact(valueStr, Formats, CultureInfo.InvariantCulture, DateTimeStyles.None, out timeStamp);
 
-        return timeStamp;
+        return timeStamp.ToUniversalTime();
     }
 
     private DateTime CustomParse(string value)

--- a/src/Serilog.Ui.MsSqlServerProvider/Extensions/SerilogUiOptionBuilderExtensions.cs
+++ b/src/Serilog.Ui.MsSqlServerProvider/Extensions/SerilogUiOptionBuilderExtensions.cs
@@ -20,7 +20,10 @@ namespace Serilog.Ui.MsSqlServerProvider
         /// <param name="schemaName">
         ///     Name of the table schema. default value is <c> dbo </c>
         /// </param>
-        /// <param name="dateTimeCustomParsing">Delegate to customize the DateTime parsing. It must return a DateTime with UTC</param>
+        /// <param name="dateTimeCustomParsing">
+        /// Delegate to customize the DateTime parsing.
+        ///  It throws <see cref="InvalidOperationException" /> if the return DateTime isn't UTC kind.
+        /// </param>
         /// <exception cref="ArgumentNullException"> throw if connectionString is null </exception>
         /// <exception cref="ArgumentNullException"> throw is tableName is null </exception>
         public static SerilogUiOptionsBuilder UseSqlServer(
@@ -46,7 +49,7 @@ namespace Serilog.Ui.MsSqlServerProvider
 
             SqlMapper.AddTypeHandler(new DapperDateTimeHandler(dateTimeCustomParsing));
 
-            ((ISerilogUiOptionsBuilder)optionsBuilder).Services
+            ((ISerilogUiOptionsBuilder) optionsBuilder).Services
                 .AddScoped<IDataProvider, SqlServerDataProvider>(p =>
                     ActivatorUtilities.CreateInstance<SqlServerDataProvider>(p, relationProvider));
 

--- a/src/Serilog.Ui.MsSqlServerProvider/Serilog.Ui.MsSqlServerProvider.csproj
+++ b/src/Serilog.Ui.MsSqlServerProvider/Serilog.Ui.MsSqlServerProvider.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
-		<Version>2.2.3-alpha-1</Version>
+		<Version>2.2.3</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Serilog.Ui.MsSqlServerProvider/Serilog.Ui.MsSqlServerProvider.csproj
+++ b/src/Serilog.Ui.MsSqlServerProvider/Serilog.Ui.MsSqlServerProvider.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
-		<Version>2.2.2</Version>
+		<Version>2.2.3-alpha-1</Version>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -12,6 +12,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\Serilog.Ui.Core\Serilog.Ui.Core.csproj" />
+		<ProjectReference Include="..\Serilog.Ui.Core\Serilog.Ui.Core.csproj" PrivateAssets="All" />
 	</ItemGroup>
 </Project>

--- a/src/Serilog.Ui.MsSqlServerProvider/SqlServerDataProvider.cs
+++ b/src/Serilog.Ui.MsSqlServerProvider/SqlServerDataProvider.cs
@@ -18,11 +18,6 @@ namespace Serilog.Ui.MsSqlServerProvider
             _options = options ?? throw new ArgumentNullException(nameof(options));
         }
 
-        static SqlServerDataProvider()
-        {
-            SqlMapper.AddTypeHandler(new DapperDateTimeHandler());
-        }
-
         public string Name => _options.ToDataProviderName("MsSQL");
 
         public async Task<(IEnumerable<LogModel>, int)> FetchDataAsync(

--- a/src/Serilog.Ui.Web/package-lock.json
+++ b/src/Serilog.Ui.Web/package-lock.json
@@ -8,7 +8,7 @@
       "name": "serilog-ui",
       "version": "1.0.0",
       "dependencies": {
-        "@fortawesome/fontawesome-free": "6.4.0",
+        "@fortawesome/fontawesome-free": "^6.5.1",
         "bootstrap": "4.5.3",
         "date-fns": "^2.29.3",
         "jquery": "^3.6.4",
@@ -24,7 +24,7 @@
         "@types/jest": "^29.5.1",
         "@types/jquery": "^3.5.16",
         "@types/jsdom": "^21.1.1",
-        "@types/node": "^18.16.1",
+        "@types/node": "^20.10.6",
         "@types/parcel-bundler": "^1.12.5",
         "grunt": "^1.6.1",
         "grunt-contrib-clean": "^2.0.1",
@@ -677,9 +677,9 @@
       "dev": true
     },
     "node_modules/@fortawesome/fontawesome-free": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.4.0.tgz",
-      "integrity": "sha512-0NyytTlPJwB/BF5LtRV8rrABDbe3TdTXqNB3PdZ+UUUZAEIrdOJdmABqKjt4AXwIoJNaRVVZEXxpNrqvE1GAYQ==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.5.1.tgz",
+      "integrity": "sha512-CNy5vSwN3fsUStPRLX7fUYojyuzoEMSXPl7zSLJ8TgtRfjv24LOnOWKT2zYwaHZCJGkdyRnTmstR0P+Ah503Gw==",
       "hasInstallScript": true,
       "engines": {
         "node": ">=6"
@@ -3201,9 +3201,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.19.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.4.tgz",
-      "integrity": "sha512-xNzlUhzoHotIsnFoXmJB+yWmBvFZgKCI9TtPIEdYIMM1KWfwuY8zh7wvc1u1OAXlC7dlf6mZVx/s+Y5KfFz19A==",
+      "version": "20.10.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.6.tgz",
+      "integrity": "sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"

--- a/src/Serilog.Ui.Web/package-lock.json
+++ b/src/Serilog.Ui.Web/package-lock.json
@@ -17,14 +17,14 @@
         "xml-formatter": "^3.6.0"
       },
       "devDependencies": {
-        "@testing-library/dom": "^9.2.0",
+        "@testing-library/dom": "^9.3.4",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/user-event": "^14.4.3",
         "@types/bootstrap": "^5.2.6",
         "@types/jest": "^29.5.1",
         "@types/jquery": "^3.5.16",
         "@types/jsdom": "^21.1.1",
-        "@types/node": "^20.10.6",
+        "@types/node": "^20.11.0",
         "@types/parcel-bundler": "^1.12.5",
         "grunt": "^1.6.1",
         "grunt-contrib-clean": "^2.0.1",
@@ -2914,9 +2914,9 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.3.tgz",
-      "integrity": "sha512-fB0R+fa3AUqbLHWyxXa2kGVtf1Fe1ZZFr0Zp6AIbIAzXb2mKbEXl+PCQNUOaq5lbTab5tfctfXRNsWXxa2f7Aw==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
+      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -3201,9 +3201,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.10.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.6.tgz",
-      "integrity": "sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==",
+      "version": "20.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.0.tgz",
+      "integrity": "sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"

--- a/src/Serilog.Ui.Web/package.json
+++ b/src/Serilog.Ui.Web/package.json
@@ -12,14 +12,14 @@
     "test:ci": "jest --ci --reporters=default --reporters=jest-junit"
   },
   "devDependencies": {
-    "@testing-library/dom": "^9.2.0",
+    "@testing-library/dom": "^9.3.4",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/user-event": "^14.4.3",
     "@types/bootstrap": "^5.2.6",
     "@types/jest": "^29.5.1",
     "@types/jquery": "^3.5.16",
     "@types/jsdom": "^21.1.1",
-    "@types/node": "^20.10.6",
+    "@types/node": "^20.11.0",
     "@types/parcel-bundler": "^1.12.5",
     "grunt": "^1.6.1",
     "grunt-contrib-clean": "^2.0.1",

--- a/src/Serilog.Ui.Web/package.json
+++ b/src/Serilog.Ui.Web/package.json
@@ -19,7 +19,7 @@
     "@types/jest": "^29.5.1",
     "@types/jquery": "^3.5.16",
     "@types/jsdom": "^21.1.1",
-    "@types/node": "^18.16.1",
+    "@types/node": "^20.10.6",
     "@types/parcel-bundler": "^1.12.5",
     "grunt": "^1.6.1",
     "grunt-contrib-clean": "^2.0.1",
@@ -37,7 +37,7 @@
     "whatwg-fetch": "^3.6.2"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "6.4.0",
+    "@fortawesome/fontawesome-free": "^6.5.1",
     "bootstrap": "4.5.3",
     "date-fns": "^2.29.3",
     "jquery": "^3.6.4",

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,24 +1,26 @@
 <Project>
-	<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-
-	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.12.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-		<PackageReference Include="NSubstitute" Version="5.0.0" />
-		<PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.16">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="Testcontainers" Version="3.4.0" />
-		<PackageReference Include="xunit" Version="2.5.0" />
-		<PackageReference Include="xunit.extensibility.core" Version="2.5.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.0">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-	</ItemGroup>
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute"/>
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.12.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="NSubstitute" Version="5.0.0"/>
+        <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.16">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Testcontainers" Version="3.4.0"/>
+        <PackageReference Include="xunit" Version="2.5.0"/>
+        <PackageReference Include="xunit.extensibility.core" Version="2.5.0"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
 </Project>

--- a/tests/Serilog.Ui.Common.Tests/Serilog.Ui.Common.Tests.csproj
+++ b/tests/Serilog.Ui.Common.Tests/Serilog.Ui.Common.Tests.csproj
@@ -15,10 +15,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<ProjectReference Include="..\..\src\Serilog.Ui.Core\Serilog.Ui.Core.csproj" />
 		<ProjectReference Include="..\..\src\Serilog.Ui.MongoDbProvider\Serilog.Ui.MongoDbProvider.csproj" />
 	</ItemGroup>

--- a/tests/Serilog.Ui.MsSqlServerProvider.Tests/DapperHandlers/DapperDateTimeHandlerTest.cs
+++ b/tests/Serilog.Ui.MsSqlServerProvider.Tests/DapperHandlers/DapperDateTimeHandlerTest.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Data;
+using System.Globalization;
+using System.Threading;
+using FluentAssertions;
+using Microsoft.Data.SqlClient;
+using Serilog.Ui.MsSqlServerProvider;
+using Xunit;
+
+namespace MsSql.Tests.DapperHandlers;
+
+public class DapperDateTimeHandlerTest
+{
+    private readonly DapperDateTimeHandler _sut = new();
+
+    [Fact]
+    public void It_parse_simple_datetime_with_local_style_and_current_culture()
+    {
+        // ARRANGE
+        var specificCulture = CultureInfo.CreateSpecificCulture("en-US");
+        var time = new DateTime(1999, 12, 31, 01, 02, 40, DateTimeKind.Local);
+        var stringify = time.ToString("yyyy-MM-dd hh:mm:ss", specificCulture);
+        Thread.CurrentThread.CurrentCulture = specificCulture;
+        // ACT
+        var result = _sut.Parse(stringify);
+
+        // ASSERT
+        result.Should().Be(time.ToUniversalTime());
+        result.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [Theory]
+    [InlineData("M/d/yyyy h:mm:ss tt zzz")]
+    [InlineData("M/dd/yyyy h:mm:ss tt zzz")]
+    [InlineData("M/d/yyyy h:mm:ss tt")]
+    [InlineData("M/dd/yyyy h:mm:ss tt")]
+    [InlineData("M/dd/yyyy hh:mm:ss")]
+    [InlineData("MM/dd/yyyy HH:mm:ss")]
+    [InlineData("MM/d/yyyy hh:mm:ss tt")]
+    [InlineData("M/dd/yyyy hh:mm:ss tt")]
+    [InlineData("MM/dd/yyyy hh:mm:ss tt")]
+    public void It_parse_exact_formats_with_none_style_and_invariant_culture(string customFormat)
+    {
+        // ARRANGE
+        var specificCulture = CultureInfo.CreateSpecificCulture("en-US");
+        var time = new DateTime(1999, 12, 31, 01, 02, 40, DateTimeKind.Unspecified);
+        var stringify = time.ToString(customFormat, specificCulture);
+        Thread.CurrentThread.CurrentCulture = specificCulture;
+        // ACT
+        var result = _sut.Parse(stringify);
+
+        // ASSERT
+        result.Should().Be(time.ToUniversalTime());
+        result.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [Fact]
+    public void It_parse_strange_format_using_custom_delegate()
+    {
+        // ARRANGE
+        var sut = new DapperDateTimeHandler(par => DateTime
+            .ParseExact(par, "MM/dd/yyyy ss|mm|hh", CultureInfo.CreateSpecificCulture("en-US"), DateTimeStyles.AssumeLocal)
+            .ToUniversalTime()
+        );
+        var time = new DateTime(1999, 12, 31, 01, 02, 40, DateTimeKind.Local);
+        var stringifyStrangeFormat = time.ToString("MM/dd/yyyy ss|mm|hh", CultureInfo.CreateSpecificCulture("en-US"));
+
+        // ACT
+        var result = sut.Parse(stringifyStrangeFormat);
+
+        // ASSERT
+        var originalUtcTime = time.ToUniversalTime();
+        result.Should().Be(originalUtcTime);
+        result.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [Fact]
+    public void It_fail_parse_with_current_culture_when_original_format_culture_was_different()
+    {
+        // ARRANGE
+        var time = new DateTime(1999, 12, 31, 01, 02, 40, DateTimeKind.Local);
+        var stringifyWithDifferentCulture = time.ToString("MM/dd/yyyy", CultureInfo.CreateSpecificCulture("en-US"));
+        Thread.CurrentThread.CurrentCulture = CultureInfo.CreateSpecificCulture("es-AR");
+
+        // ACT
+        var result = _sut.Parse(stringifyWithDifferentCulture);
+
+        // ASSERT
+        result.Should().Be(DateTime.MinValue);
+    }
+
+    [Fact]
+    public void It_throws_when_using_custom_delegate_not_returns_datetime_with_utc_kind()
+    {
+        var sut = new DapperDateTimeHandler(par => DateTime
+            .ParseExact(par, "MM/dd/yyyy", CultureInfo.CreateSpecificCulture("en-US"), DateTimeStyles.AssumeLocal)
+        );
+        var time = new DateTime(1999, 12, 31, 01, 02, 40, DateTimeKind.Local);
+        var stringify = time.ToString("MM/dd/yyyy", CultureInfo.CreateSpecificCulture("en-US"));
+
+        var result = () => sut.Parse(stringify);
+
+        result.Should().ThrowExactly<InvalidOperationException>().WithMessage($"The parsed date must have kind: {DateTimeKind.Utc}");
+    }
+
+    [Fact]
+    public void It_sets_value_without_changes()
+    {
+        var param = new SqlParameter("test", SqlDbType.Date);
+        var value = DateTime.Now.AddHours(-2);
+        _sut.SetValue(param, value);
+
+        param.Value.Should().BeAssignableTo<DateTime>().And.Be(value);
+    }
+}


### PR DESCRIPTION
This PR aims to fix #96, by changing the default datetime parsing in MS SQL Provider. 

The default parse will assume that the date saved in the database is related to the application culture, assuming it's local based.

If the user isn't satisfied by the default parsing, a new parameter can be used to customize the datetime parsing. The DateTime produced must be UTC-kind or the app will throw an exception.

EDIT: it also bumps npm libraries (will close the other PRs later)