### PR TITLE
feat: Replace Newtonsoft.Json with System.Text.Json

### DIFF
--- a/src/Serilog.Ui.Core/Serilog.Ui.Core.csproj
+++ b/src/Serilog.Ui.Core/Serilog.Ui.Core.csproj
@@ -7,6 +7,5 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>
 </Project>

--- a/src/Serilog.Ui.MongoDbProvider/Serilog.Ui.MongoDbProvider.csproj
+++ b/src/Serilog.Ui.MongoDbProvider/Serilog.Ui.MongoDbProvider.csproj
@@ -9,6 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="MongoDB.Driver" Version="2.21.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Serilog.Ui.Web/Endpoints/SerilogUiAppRoutes.cs
+++ b/src/Serilog.Ui.Web/Endpoints/SerilogUiAppRoutes.cs
@@ -1,23 +1,22 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
-using Newtonsoft.Json;
+using System.Text.Json;
 using System;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Serialization;
 using Ardalis.GuardClauses;
 
 namespace Serilog.Ui.Web.Endpoints
 {
     internal class SerilogUiAppRoutes : ISerilogUiAppRoutes
     {
-        private static readonly JsonSerializerSettings _jsonSerializerOptions = new()
+        private static readonly JsonSerializerOptions JsonSerializerOptions = new()
         {
-            NullValueHandling = NullValueHandling.Ignore,
-            ContractResolver = new CamelCasePropertyNamesContractResolver(),
-            Formatting = Formatting.None
+            IgnoreNullValues = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };
+
         private readonly IAppStreamLoader _streamLoader;
 
         public SerilogUiAppRoutes(IAppStreamLoader appStreamLoader)
@@ -67,7 +66,7 @@ namespace Serilog.Ui.Web.Endpoints
         {
             var htmlStringBuilder = new StringBuilder(await new StreamReader(stream).ReadToEndAsync());
             var authType = options.Authorization.AuthenticationType.ToString();
-            var encodeAuthOpts = Uri.EscapeDataString(JsonConvert.SerializeObject(new { options.RoutePrefix, authType, options.HomeUrl }, _jsonSerializerOptions));
+            var encodeAuthOpts = Uri.EscapeDataString(JsonSerializer.Serialize(new { options.RoutePrefix, authType, options.HomeUrl }, JsonSerializerOptions));
 
             htmlStringBuilder
                 .Replace("%(Configs)", encodeAuthOpts)

--- a/src/Serilog.Ui.Web/Serilog.UI.nuspec
+++ b/src/Serilog.Ui.Web/Serilog.UI.nuspec
@@ -19,25 +19,21 @@
 			<group targetFramework=".NETCoreApp3.1">
 				<dependency id="Ardalis.GuardClauses" version="4.0.1" exclude="Build,Analyzers" />
 				<dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="3.1.3" exclude="Build,Analyzers" />
-				<dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
 				<dependency id="Scrutor" version="4.2.2" exclude="Build,Analyzers" />
 			</group>
 			<group targetFramework=".NET5.0">
 				<dependency id="Ardalis.GuardClauses" version="4.0.1" exclude="Build,Analyzers" />
 				<dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="5.0.0" exclude="Build,Analyzers" />
-				<dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
 				<dependency id="Scrutor" version="4.2.2" exclude="Build,Analyzers" />
 			</group>
 			<group targetFramework=".NET6.0">
 				<dependency id="Ardalis.GuardClauses" version="4.0.1" exclude="Build,Analyzers" />
 				<dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
-				<dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
 				<dependency id="Scrutor" version="4.2.2" exclude="Build,Analyzers" />
 			</group>
 			<group targetFramework=".NET7.0">
 				<dependency id="Ardalis.GuardClauses" version="4.0.1" exclude="Build,Analyzers" />
 				<dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="7.0.0" exclude="Build,Analyzers" />
-				<dependency id="Newtonsoft.Json" version="13.0.3" exclude="Build,Analyzers" />
 				<dependency id="Scrutor" version="4.2.2" exclude="Build,Analyzers" />
 			</group>
 		</dependencies>

--- a/tests/Serilog.Ui.Common.Tests/DataSamples/LogModelFaker.cs
+++ b/tests/Serilog.Ui.Common.Tests/DataSamples/LogModelFaker.cs
@@ -1,5 +1,4 @@
 ﻿using Bogus;
-using Newtonsoft.Json;
 using Serilog.Ui.Core;
 using System;
 using System.Collections.Generic;
@@ -21,7 +20,7 @@ namespace Serilog.Ui.Common.Tests.DataSamples
              .RuleFor(p => p.RowNo, f => f.Database.Random.Int())
              .RuleFor(p => p.Level, f => f.PickRandom(LogLevels))
              .RuleFor(p => p.Properties, PropertiesFaker.SerializedProperties)
-             .RuleFor(p => p.Exception, (f) => JsonConvert.SerializeObject(f.System.Exception()))
+             .RuleFor(p => p.Exception, (f) => f.System.Exception().ToString())
              .RuleFor(p => p.Message, f => f.System.Random.Words(6))
              .RuleFor(p => p.PropertyType, f => f.System.CommonFileType())
              .RuleFor(p => p.Timestamp, f => new DateTime(f.Date.Recent().Ticks, DateTimeKind.Utc));

--- a/tests/Serilog.Ui.Common.Tests/DataSamples/LogModelPropsCollector.cs
+++ b/tests/Serilog.Ui.Common.Tests/DataSamples/LogModelPropsCollector.cs
@@ -8,6 +8,11 @@ namespace Serilog.Ui.Common.Tests.DataSamples
     public class LogModelPropsCollector
     {
         public LogModelPropsCollector(IEnumerable<LogModel> models)
+            : this(models.ToList())
+        {
+        }
+
+        public LogModelPropsCollector(ICollection<LogModel> models)
         {
             DataSet = models.ToList();
             Collect(models);
@@ -19,7 +24,7 @@ namespace Serilog.Ui.Common.Tests.DataSamples
         public IEnumerable<DateTime> TimesSamples { get; private set; }
         public IEnumerable<string> MessagePiecesSamples { get; private set; }
 
-        private void Collect(IEnumerable<LogModel> models)
+        private void Collect(ICollection<LogModel> models)
         {
             Example = models.First();
 
@@ -29,15 +34,15 @@ namespace Serilog.Ui.Common.Tests.DataSamples
 
             MessagePiecesSamples = new List<string>
             {
-                models.ElementAtOrDefault(0).Message,
-                models.ElementAtOrDefault(1).Message.Substring(1, models.ElementAtOrDefault(1).Message.Length / 2),
-                models.ElementAtOrDefault(2).Message.Substring(1, models.ElementAtOrDefault(2).Message.Length / 2),
+                models.ElementAt(0).Message,
+                models.ElementAt(1).Message.Substring(1, models.ElementAt(1).Message.Length / 2),
+                models.ElementAt(2).Message.Substring(1, models.ElementAt(2).Message.Length / 2),
             };
             TimesSamples = new List<DateTime>
             {
-                models.ElementAtOrDefault(0).Timestamp,
-                models.ElementAtOrDefault(1).Timestamp,
-                models.ElementAtOrDefault(2).Timestamp,
+                models.ElementAt(0).Timestamp,
+                models.ElementAt(1).Timestamp,
+                models.ElementAt(2).Timestamp,
             }.OrderBy(p => p.Ticks);
         }
     }

--- a/tests/Serilog.Ui.Common.Tests/DataSamples/MongoDbLogModelFaker.cs
+++ b/tests/Serilog.Ui.Common.Tests/DataSamples/MongoDbLogModelFaker.cs
@@ -1,10 +1,10 @@
 ﻿using MongoDB.Bson;
-using Newtonsoft.Json;
 using Serilog.Ui.Common.Tests.FakeObjectModels;
 using Serilog.Ui.MongoDbProvider;
-using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
+using Bogus;
 
 namespace Serilog.Ui.Common.Tests.DataSamples
 {
@@ -12,18 +12,26 @@ namespace Serilog.Ui.Common.Tests.DataSamples
     {
         public static (IEnumerable<MongoDbLogModel> logs, LogModelPropsCollector collector) Logs(int generationCount)
         {
-            var originalLogs = LogModelFaker.Logs(generationCount);
+            var originalLogs = LogModelFaker.Logs(generationCount)
+                .ToList();
+
             var modelCollector = new LogModelPropsCollector(originalLogs);
-            return (originalLogs.Select(p => new MongoDbLogModel
+
+            var faker = new Faker();
+            
+            var logs = originalLogs.Select(p => new MongoDbLogModel
             {
                 Id = p.RowNo,
                 Level = p.Level,
                 RenderedMessage = p.Message,
                 Timestamp = p.Timestamp,
                 UtcTimeStamp = p.Timestamp.ToUniversalTime(),
-                Properties = JsonConvert.DeserializeObject<Properties>(p.Properties),
-                Exception = JsonConvert.DeserializeObject<Exception>(p.Exception).ToBsonDocument(),
-            }), modelCollector);
+                Properties = JsonSerializer.Deserialize<Properties>(p.Properties),
+                Exception = faker.System.Exception() // Serialization round-trip not possible for an exception, so we generate a new exception.
+                    .ToBsonDocument(),
+            });
+
+            return (logs, modelCollector);
         }
 
         public static (IEnumerable<MongoDbLogModel> logs, LogModelPropsCollector collector) Logs() => Logs(20);

--- a/tests/Serilog.Ui.Common.Tests/DataSamples/PropertiesFaker.cs
+++ b/tests/Serilog.Ui.Common.Tests/DataSamples/PropertiesFaker.cs
@@ -1,16 +1,16 @@
-﻿using Bogus;
+﻿using System.Text.Json;
+using Bogus;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using Serilog.Ui.Common.Tests.FakeObjectModels;
 
 namespace Serilog.Ui.Common.Tests.DataSamples
 {
     internal static class PropertiesFaker
     {
-        internal static Faker<Properties> Properties = new Faker<Properties>()
-            .RuleFor(p => p.EventId, f => JsonConvert.SerializeObject(new EventId(f.Random.Int(), f.Hacker.Noun())))
+        private static readonly Faker<Properties> Properties = new Faker<Properties>()
+            .RuleFor(p => p.EventId, f => new EventId(f.Random.Int(), f.Hacker.Noun()))
             .RuleForType(typeof(string), p => p.System.Random.Words(3));
 
-        internal static string SerializedProperties = JsonConvert.SerializeObject(Properties.Generate());
+        internal static readonly string SerializedProperties = JsonSerializer.Serialize(Properties.Generate());
     }
 }

--- a/tests/Serilog.Ui.Common.Tests/FakeObjectModels/Properties.cs
+++ b/tests/Serilog.Ui.Common.Tests/FakeObjectModels/Properties.cs
@@ -1,13 +1,42 @@
-﻿namespace Serilog.Ui.Common.Tests.FakeObjectModels
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace Serilog.Ui.Common.Tests.FakeObjectModels
 {
     internal class Properties
     {
         public string SourceContext { get; set; }
 
-        public object EventId { get; set; }
+        [JsonConverter(typeof(EventIdConverter))]
+        public EventId EventId { get; set; }
 
         public string Protocol { get; set; }
 
         public string Host { get; set; }
+    }
+
+    /// <summary>
+    /// A custom converter for the <see cref="EventId"/> class, since constructing an immutable struct type is not supported when [JsonConstructor] is not used.
+    /// See: <see href="https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/immutability"/>
+    /// </summary>
+    internal class EventIdConverter : JsonConverter<EventId>
+    {
+        public override EventId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var obj = (JsonObject) JsonNode.Parse(ref reader) ?? throw new JsonException();
+
+            var id = (obj[nameof(EventId.Id)] ?? throw new JsonException()).GetValue<int>();
+            var name = (obj[nameof(EventId.Name)] ?? throw new JsonException()).GetValue<string>();
+            return new EventId(id, name);
+        }
+
+        public override void Write(Utf8JsonWriter writer, EventId value, JsonSerializerOptions options)
+        {
+            // STJ handles writing fine, so we just delegate to the default implementation.
+            ((JsonConverter<EventId>)JsonSerializerOptions.Default.GetConverter(typeof(EventId))).Write(writer, value, options);
+        }
     }
 }

--- a/tests/Serilog.Ui.PostgreSqlProvider.Tests/Util/PostgresTestProvider.cs
+++ b/tests/Serilog.Ui.PostgreSqlProvider.Tests/Util/PostgresTestProvider.cs
@@ -40,7 +40,8 @@ namespace Postgres.Tests.Util
 
         protected override async Task InitializeAdditionalAsync()
         {
-            var logs = LogModelFaker.Logs(100);
+            var logs = LogModelFaker.Logs(100)
+                .ToList();
 
             // manual conversion due to current implementation, based on a INT level column
             var postgresTableLogs = logs.Select(p => new

--- a/tests/Serilog.Ui.Web.Tests/Endpoints/SerilogUiEndpointsTest.cs
+++ b/tests/Serilog.Ui.Web.Tests/Endpoints/SerilogUiEndpointsTest.cs
@@ -2,7 +2,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
-using Newtonsoft.Json;
 using Serilog.Ui.Core;
 using Serilog.Ui.Web.Endpoints;
 using System;
@@ -10,6 +9,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
@@ -118,7 +118,7 @@ namespace Ui.Web.Tests.Endpoints
             mockProvider.Received().GetService(typeof(AggregateDataProvider));
             _testContext.Response.Body.Seek(0, SeekOrigin.Begin);
             var result = await new StreamReader(_testContext.Response.Body).ReadToEndAsync();
-            return JsonConvert.DeserializeObject<T>(result)!;
+            return JsonSerializer.Deserialize<T>(result)!;
         }
 
         private class FakeProvider : IDataProvider
@@ -163,13 +163,13 @@ namespace Ui.Web.Tests.Endpoints
 
         private class AnonymousObject
         {
-            [JsonProperty("logs")]
+            [JsonPropertyName("logs")]
             public IEnumerable<LogModel>? Logs { get; set; }
-            [JsonProperty("total")]
+            [JsonPropertyName("total")]
             public int Total { get; set; }
-            [JsonProperty("count")]
+            [JsonPropertyName("count")]
             public int Count { get; set; }
-            [JsonProperty("currentPage")]
+            [JsonPropertyName("currentPage")]
             public int CurrentPage { get; set; }
         }
     }

--- a/tests/Serilog.Ui.Web.Tests/Utilities/InMemoryDataProvider/InMemoryDataProvider.cs
+++ b/tests/Serilog.Ui.Web.Tests/Utilities/InMemoryDataProvider/InMemoryDataProvider.cs
@@ -1,10 +1,10 @@
-﻿using Newtonsoft.Json;
-using Serilog.Events;
+﻿using Serilog.Events;
 using Serilog.Sinks.InMemory;
 using Serilog.Ui.Core;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace Ui.Web.Tests.Utilities.InMemoryDataProvider;
@@ -26,15 +26,18 @@ public class SerilogInMemoryDataProvider : IDataProvider
             events = events.Where(l => l.Level == logLevel);
         }
 
-        var logs = events.Skip((page - 1) * count).Take(count).Select(l => new LogModel
-        {
-            Level = l.Level.ToString(),
-            Exception = l.Exception?.ToString(),
-            Message = l.RenderMessage(),
-            Properties = JsonConvert.SerializeObject(l.Properties),
-            PropertyType = "Json",
-            Timestamp = l.Timestamp.DateTime
-        });
+        var logs = events
+            .Skip((page - 1) * count)
+            .Take(count)
+            .Select(l => new LogModel
+            {
+                Level = l.Level.ToString(),
+                Exception = l.Exception?.ToString(),
+                Message = l.RenderMessage(),
+                Properties = JsonSerializer.Serialize(l.Properties),
+                PropertyType = "Json",
+                Timestamp = l.Timestamp.DateTime
+            });
 
         return Task.FromResult((logs, events.Count()));
     }


### PR DESCRIPTION
Closes https://github.com/serilog-contrib/serilog-ui/issues/61.

This PR aims to remove jsonnet and replace it with STJ.

JsonNet was removed from Core and Web projects, including .nuspec of the web project.
Only 2 providers now use JsonNet, Elasticsearch (via Nest.JsonNetSerializer) and MongoDb.
MongoDb's ref to JsonNet could also be removed, but it serializes `[BsonElement("Properties")]` so it looked to risky. Perhaps in the future we can reevaluate this.

One test failed; `It_serializes_an_error_on_exception` which is because there was a double serialization for the error value.
I tried to fix the code so the test would remain intact, but that was hard to do.

Then when i decided i had to change the code anyways, and found no text references to 'errorMessage' anywhere else, i decided to upgrade the error feature to use the [ RFC 7807 - Problem Details for HTTP APIs](https://datatracker.ietf.org/doc/html/rfc7807). this is an industry standard also used by net core. Easily implemented with help from the renowned [Andrew Lock](https://andrewlock.net/creating-a-custom-error-handler-middleware-function/).

The test projects may still use JsonNet - i deemed that okay since its not a dependency shipped to the library consumer.
Tested with the sample app - it looks good to me. Feel free to edit or remove this PR, let me know what you think.