### PR TITLE
Fix #122: use UtcTimeStamp to sort MongoDb search results

### DIFF
--- a/src/Serilog.Ui.MongoDbProvider/MongoDbDataProvider.cs
+++ b/src/Serilog.Ui.MongoDbProvider/MongoDbDataProvider.cs
@@ -61,7 +61,7 @@ namespace Serilog.Ui.MongoDbProvider
                     .Find(builder)
                     .Skip(count * page)
                     .Limit(count)
-                    .SortByDescending(entry => entry.Timestamp)
+                    .SortByDescending(entry => entry.UtcTimeStamp)
                     .ToListAsync();
 
                 var index = 1;

--- a/src/Serilog.Ui.MongoDbProvider/Serilog.Ui.MongoDbProvider.csproj
+++ b/src/Serilog.Ui.MongoDbProvider/Serilog.Ui.MongoDbProvider.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
-		<Version>2.3.1</Version>
+		<Version>2.3.2</Version>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Fixes #122.

In v3 branch, the fix was already applied.