### PR TITLE
 fix(#130): render text content if code parsing fails

### DIFF
--- a/src/Serilog.Ui.Web/src/__tests__/util/prettyPrints.spec.ts
+++ b/src/Serilog.Ui.Web/src/__tests__/util/prettyPrints.spec.ts
@@ -134,11 +134,11 @@ describe('util: pretty prints', () => {
 
       const actXml = await renderCodeContent('not an XML!', LogType.Xml);
 
-      expect(actXml).toBe('Content could not be parsed, as per expected type: xml');
+      expect(actXml).toBe('not an XML!');
 
       const actJson = await renderCodeContent('not a JSON!', LogType.Json);
 
-      expect(actJson).toBe('Content could not be parsed, as per expected type: json');
+      expect(actJson).toBe('not a JSON!');
 
       expect(consoleMock).toHaveBeenCalledTimes(2);
     });

--- a/src/Serilog.Ui.Web/src/app/util/prettyPrints.ts
+++ b/src/Serilog.Ui.Web/src/app/util/prettyPrints.ts
@@ -83,7 +83,7 @@ export const renderCodeContent = async (
       });
     }
   } catch {
-    console.warn(`${modalContent} is not a valid json!`);
-    return `Content could not be parsed, as per expected type: ${contentType}`;
+    console.warn(`Content could not be parsed, as per expected type: ${contentType}`);
+    return modalContent;
   }
 };


### PR DESCRIPTION
PR to propagate part of the feature from #135, that will be included in a minor release, as a fix to include in v3.0.1 UI